### PR TITLE
since we must load an image for every file, it makes sense to load di…

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -180,8 +180,7 @@ Item {
                             Layout.maximumWidth: 100
                             Layout.fillHeight: true
                             Layout.fillWidth: false
-                            source: model.modelData.isDir ? "qrc:/img/directory_icon.png" :
-                                    "image://thumbnail/" + model.modelData.filePath + "/" + model.modelData.fileName
+                            source: "image://thumbnail/" + model.modelData.filePath + "/" + model.modelData.fileName
                         }
 
                         MoreporkButton {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -10,12 +10,16 @@ QPixmap ThumbnailPixmapProvider::requestPixmap(const QString &kAbsoluteFilePath,
 #ifdef HAVE_LIBTINYTHING
   const QFileInfo kFileInfo(kAbsoluteFilePath);
   if(kFileInfo.exists()){
-    MakerbotFileMetaReader file_meta_reader(kFileInfo);
-    QImage thumbnail = file_meta_reader.getMediumThumbnail();
-    if(thumbnail.isNull())
-      return QPixmap::fromImage(QImage(":/img/makerbot_logo_110x80.png"));
-    else
-      return QPixmap::fromImage(thumbnail);
+    if(kFileInfo.isDir())
+      return QPixmap::fromImage(QImage(":/img/directory_icon.png"));
+    else{
+      MakerbotFileMetaReader file_meta_reader(kFileInfo);
+      QImage thumbnail = file_meta_reader.getMediumThumbnail();
+      if(thumbnail.isNull())
+        return QPixmap::fromImage(QImage(":/img/makerbot_logo_110x80.png"));
+      else
+        return QPixmap::fromImage(thumbnail);
+    }
   }
   else
 #endif


### PR DESCRIPTION
…rectory_icon.png in the thumbnail pixmap list instead of the makerbot logo.