### PR TITLE
minor fix for sort not using default value on first run

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -33,6 +33,7 @@ MoreporkStorage::MoreporkStorage(){
   usb_storage_watcher_ = new QFileSystemWatcher();
   usb_storage_watcher_->addPath("/dev/disk/by-path");
   prev_thing_dir_ = "";
+  m_sortType = PrintFileInfo::StorageSortType::Alphabetic;
   connect(storage_watcher_, SIGNAL(directoryChanged(const QString)),
           this, SLOT(updateStorageFileList(const QString)));
   connect(usb_storage_watcher_, SIGNAL(directoryChanged(const QString)),


### PR DESCRIPTION
SortType isn't getting initialized to the default value 'Alphabetic' set through the MODEL_PROP macro. So when storage is opened and files listed for the first time on UI they aren't sorted alphabetically, though changing the sort type later works. Therefore setting the variable explicitly in the constructor. This wasn't happening before the 'fetch print file details from current_thing directory' merge.