### PR TITLE
Fix for UI crash when print started from UI

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -50,11 +50,13 @@ Item {
             if(printSwipeView.currentIndex != 0) {
                 printSwipeView.swipeToItem(0)
             }
-            waitingForPrintToStart = false //reset when the print actually starts
             setDrawerState(false)
             activeDrawer = printPage.printingDrawer
             setDrawerState(true)
-            getPrintDetailsTImer.start() //for prints started from repl
+            if(!waitingForPrintToStart) {
+                getPrintDetailsTimer.start() //for prints started from repl
+            }
+            waitingForPrintToStart = false //reset when the print actually starts
         }
         else {
             printStatusView.printStatusSwipeView.setCurrentIndex(0)
@@ -73,7 +75,7 @@ Item {
     }
 
     Timer {
-        id: getPrintDetailsTImer
+        id: getPrintDetailsTimer
         interval: 3000
         onTriggered: {
             storage.updateCurrentThing()


### PR DESCRIPTION
The method to look into the current things folder automatically when the bot goes into print process and fetch the print file details crashes the UI, when the print is started from the UI. It might be because the symbolic link in current things folder isn't properly resolved or created when all of the components aren't hooked up to the bot. But since we actually start the print from the UI we don't need to fetch the print file details this way as we already have them. So now the fetch details method only runs when the bot goes into print process when the print wasn't started through UI. This is only a special case for prints started from repl, the 'print file valid' notification is used otherwise for this purpose when a file is actually transferred to the bot before printing.