### PR TITLE
Fetch elapsed time on print completion

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -64,6 +64,7 @@ class ProcessModel : public BaseModel {
     MODEL_PROP(bool, printFileValid, false)
     MODEL_PROP(int, printPercentage, 0)
     MODEL_PROP(int, timeRemaining, 0)
+    MODEL_PROP(int, elapsedTime, 0)
     MODEL_PROP(int, errorCode, 0)
     MODEL_PROP(int, targetHesUpper, 3800)
     MODEL_PROP(int, targetHesLower, 3400)

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -119,6 +119,7 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
 
     UPDATE_INT_PROP(printPercentage, proc["progress"]);
     UPDATE_INT_PROP(timeRemaining, proc["time_remaining"]);
+    UPDATE_INT_PROP(elapsedTime, proc["elapsed_time"]);
     activeSet(true);
 }
 

--- a/src/qml/PrintIconForm.qml
+++ b/src/qml/PrintIconForm.qml
@@ -84,7 +84,8 @@ Item {
                 from: 360000;
                 to: 0;
                 duration: 10000000
-                running: parent.visible
+                running: (bot.process.stateType == ProcessStateType.Loading ||
+                          bot.process.stateType == ProcessStateType.Preheating)
             }
         }
 
@@ -108,7 +109,12 @@ Item {
                 from: 0;
                 to: 360000;
                 duration: 10000000
-                running: parent.visible
+                running: (bot.process.stateType == ProcessStateType.Loading ||
+                          bot.process.stateType == ProcessStateType.Paused ||
+                          bot.process.stateType == ProcessStateType.Pausing ||
+                          bot.process.stateType == ProcessStateType.Resuming ||
+                          bot.process.stateType == ProcessStateType.Preheating || // Out of filament
+                          bot.process.stateType == ProcessStateType.UnloadingFilament) // while printing
             }
         }
 

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -2,6 +2,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import ProcessTypeEnum 1.0
+import ProcessStateTypeEnum 1.0
 
 Item {
     smooth: false
@@ -82,6 +83,20 @@ Item {
             storage.updateCurrentThing()
             getPrintFileDetails(storage.currentThing)
             this.stop()
+        }
+    }
+
+    property bool isPrintFinished: bot.process.stateType == ProcessStateType.Completed ||
+                                   bot.process.stateType == ProcessStateType.Failed
+
+    onIsPrintFinishedChanged: {
+        if(isPrintFinished) {
+            var timeElapsed = new Date("", "", "", "", "", bot.process.elapsedTime)
+            print_time = timeElapsed.getDate() != 31 ?
+                        timeElapsed.getDate() + "D " + timeElapsed.getHours() + "HR " + timeElapsed.getMinutes() + "M" :
+                        timeElapsed.getHours() != 0 ?
+                            timeElapsed.getHours() + "HR " + timeElapsed.getMinutes() + "M" :
+                            timeElapsed.getMinutes() + "M"
         }
     }
 


### PR DESCRIPTION
...and show that on the print completed/failed screen instead of showing the total print time estimate. Also fixed a bug in the print icon that I introduced in the previous PR.