### PR TITLE
Better UI indication while heating up

### DIFF
--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -122,7 +122,8 @@ Item {
                     text: {
                         switch(bot.process.stateType) {
                         case ProcessStateType.Loading:
-                            "HEATING UP..."
+                            bot.extruderATargetTemp > 0 ? "HEATING UP EXTRUDER..." :
+                                                          "HEATING UP CHAMBER..."
                             break;
                         case ProcessStateType.Printing:
                             fileName_
@@ -163,7 +164,9 @@ Item {
                     text: {
                         switch(bot.process.stateType) {
                         case ProcessStateType.Loading:
-                            bot.extruderACurrentTemp + " C" + " | " + bot.extruderATargetTemp + " C"
+                            bot.extruderATargetTemp > 0 ?
+                                (bot.extruderACurrentTemp + " C" + " | " + bot.extruderATargetTemp + " C") :
+                                (bot.chamberCurrentTemp + " C" + " | " + bot.chamberTargetTemp + " C")
                             break;
                         case ProcessStateType.Printing:
                         case ProcessStateType.Pausing:


### PR DESCRIPTION
Indicate what is heating up (extruder or chamber) and what are its respective current and target temps. rather than always showing 'heating up' and the extruder current & target temps.