### PR TITLE
BW-4335-Fix popups in Qt 5.10

### DIFF
--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -131,6 +131,7 @@ Item {
         modal: true
         dim: false
         focus: true
+        parent: overlay
         closePolicy: Popup.CloseOnPressOutside
         background: Rectangle {
             id: popupBackgroundDim
@@ -156,7 +157,6 @@ Item {
             border.width: 2
             border.color: "#ffffff"
             anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: rotation == 180 ? 40 : -40
             anchors.horizontalCenter: parent.horizontalCenter
 
             Rectangle {
@@ -316,6 +316,7 @@ Item {
         modal: true
         dim: false
         focus: true
+        parent: overlay
         closePolicy: Popup.CloseOnPressOutside
         background: Rectangle {
             id: popupBackgroundDim1
@@ -341,7 +342,6 @@ Item {
             border.width: 2
             border.color: "#ffffff"
             anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: rotation == 180 ? 40 : -40
             anchors.horizontalCenter: parent.horizontalCenter
 
             Text {

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -337,7 +337,7 @@ ApplicationWindow {
             dim: false
             focus: true
             closePolicy: Popup.CloseOnPressOutside
-            parent: Overlay.overlay
+            parent: overlay
             background: Rectangle {
                 id: popupBackgroundDim
                 color: "#000000"
@@ -596,7 +596,7 @@ ApplicationWindow {
             dim: false
             focus: true
             closePolicy: Popup.CloseOnPressOutside
-            parent: Overlay.overlay
+            parent: overlay
             background: Rectangle {
                 id: popupBackgroundDim1
                 color: "#000000"
@@ -830,6 +830,7 @@ ApplicationWindow {
             modal: true
             dim: false
             focus: true
+            parent: overlay
             closePolicy: Popup.CloseOnPressOutside
             background: Rectangle {
                 id: popupBackgroundDim2
@@ -1024,7 +1025,7 @@ ApplicationWindow {
             dim: false
             focus: true
             closePolicy: Popup.CloseOnPressOutside
-            parent: Overlay.overlay
+            parent: overlay
             background: Rectangle {
                 id: updatingExtruderFirmwareBackRect
                 color: "#000000"

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -298,6 +298,7 @@ Item {
         modal: true
         dim: false
         focus: true
+        parent: overlay
         closePolicy: Popup.NoAutoClose
         background: Rectangle {
             id: popupBackgroundDim
@@ -329,7 +330,6 @@ Item {
             border.width: 2
             border.color: "#ffffff"
             anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: rotation == 180 ? 55 : -55
             anchors.horizontalCenter: parent.horizontalCenter
 
             Rectangle {

--- a/src/qml/ToolheadCalibrationForm.qml
+++ b/src/qml/ToolheadCalibrationForm.qml
@@ -385,6 +385,7 @@ Item {
         modal: true
         dim: false
         focus: true
+        parent: overlay
         closePolicy: Popup.CloseOnPressOutside
         background: Rectangle {
             id: popupBackgroundDim
@@ -414,7 +415,6 @@ Item {
             border.width: 2
             border.color: "#ffffff"
             anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: rotation == 180 ? 40 : -40
             anchors.horizontalCenter: parent.horizontalCenter
 
             Rectangle {


### PR DESCRIPTION
Popups are back! Also the new positioning scheme forces to always use the entire window as parent irrespective of where the popup is actually defined in the UI which helps us to get rid of offsets we had in place for the popups due to their parent's offsets' wrt. to the root window.