### PR TITLE
Minor ui fix in calibrate toolheads page.

### DIFF
--- a/src/qml/ToolheadCalibrationForm.qml
+++ b/src/qml/ToolheadCalibrationForm.qml
@@ -33,7 +33,7 @@ Item {
                 state = "cancelling"
                 break;
             case ProcessStateType.CleaningUp:
-               if(state != "cancelling") {
+               if(state != "cancelling" && state != "failed") {
                    state = "calibration_finished"
                }
                break;


### PR DESCRIPTION
The ui skipped to 'calibration successful' screen even if an error occured. It is supposed to be held at 'error' screen with the error code that the user would then acknowledge. Fixed this.