### PR TITLE
BW-4315-Fix UI crash on restarting UI when the bot is already in print process

### DIFF
--- a/src/qml/PrintIconForm.qml
+++ b/src/qml/PrintIconForm.qml
@@ -78,9 +78,10 @@ Item {
                       bot.process.stateType == ProcessStateType.Preheating)
 
             RotationAnimator {
-                target: status_image;
-                from: 360000;
-                to: 0;
+                target: status_image
+                from: 360
+                to: 0
+                duration: 10000
                 loops: Animation.Infinite
                 running: (bot.process.stateType == ProcessStateType.Loading ||
                           bot.process.stateType == ProcessStateType.Preheating)
@@ -103,9 +104,10 @@ Item {
                       bot.process.stateType == ProcessStateType.UnloadingFilament) // while printing
 
             RotationAnimator {
-                target: loading_or_paused_image;
-                from: 0;
-                to: 360000;
+                target: loading_or_paused_image
+                from: 0
+                to: 360
+                duration: 10000
                 loops: Animation.Infinite
                 running: (bot.process.stateType == ProcessStateType.Loading ||
                           bot.process.stateType == ProcessStateType.Paused ||

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -46,9 +46,10 @@ MoreporkStorage::MoreporkStorage(){
 
 void MoreporkStorage::updateCurrentThing(){
   if(QDir(CURRENT_THING_PATH).exists()){
-      QDirIterator current_thing_dir(CURRENT_THING_PATH, QDir::Dirs | QDir::Files |
-        QDir::NoDotAndDotDot | QDir::Readable);
+      QDirIterator current_thing_dir(CURRENT_THING_PATH, QDir::Files |
+                            QDir::Readable | QDir::NoDotAndDotDot);
       PrintFileInfo* current_thing;
+      current_thing = nullptr;
       if(current_thing_dir.hasNext()){
         const QFileInfo kFileInfo = QFileInfo(current_thing_dir.next());
         if(kFileInfo.suffix() == "makerbot"){
@@ -104,8 +105,7 @@ void MoreporkStorage::currentThingSet(PrintFileInfo* current_thing){
 
 
 void MoreporkStorage::currentThingReset(){
-  PrintFileInfo* temp = new PrintFileInfo("/null/path", "No Items Present", "No Items Present", QDateTime(), false);
-  currentThingSet(temp);
+  currentThingSet(nullptr);
 }
 
 


### PR DESCRIPTION
Every time the bot goes into print process the UI looks into the current_things folder to fetch the details of the printing file to show on the display. This method was crashing when the UI was restarted while kaiten was still reporting the current process as print process. The pointer variable we used to fetch the .makerbot file inside the current things folder wasn't explicitly assigned a null value during declaration, which was causing the crash, it didn't happen always but happens a good amount of time to be noticeable. Also this should fix the UI freezing up on some of the bots in the lab.