### PR TITLE
BW-4397-Add cancel popup and failed, cancelling states to assisted level UI

### DIFF
--- a/src/qml/AssistedLeveling.qml
+++ b/src/qml/AssistedLeveling.qml
@@ -5,7 +5,8 @@ AssistedLevelingForm {
     startDoneButton {
         button_mouseArea.onClicked: {
             if(!startDoneButton.disable_button) {
-                if(state == "leveling_complete") {
+                if(state == "leveling_complete" ||
+                   state == "leveling_failed") {
                     processDone()
                 }
                 else {
@@ -50,5 +51,15 @@ AssistedLevelingForm {
                 }
             }
         }
+    }
+
+    cancelLeveling.onClicked: {
+        bot.cancel()
+        state = "cancelling"
+        cancelAssistedLevelingPopup.close()
+    }
+
+    continueLeveling.onClicked: {
+        cancelAssistedLevelingPopup.close()
     }
 }

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -281,18 +281,26 @@ Item {
             visible: false
 
             function altBack() {
-                bot.cancel()
-                settingsSwipeView.swipeToItem(0)
+                if(bot.process.type == ProcessType.AssistedLeveling) {
+                    assistedLevel.cancelAssistedLevelingPopup.open()
+                }
+                else {
+                    assistedLevel.state = "base state"
+                    settingsSwipeView.swipeToItem(0)
+                }
             }
 
             AssistedLeveling {
+                id: assistedLevel
                 currentHES: bot.process.currentHes
                 targetHESLower: bot.process.targetHesLower
                 targetHESUpper: bot.process.targetHesUpper
 
                 onProcessDone: {
                     state = "base state"
-                    settingsSwipeView.swipeToItem(0)
+                    if(settingsSwipeView.currentIndex != 0) {
+                        settingsSwipeView.swipeToItem(0)
+                    }
                 }
             }
         }


### PR DESCRIPTION
The assisted leveling UI always ended with leveling complete state on UI, due to kaiten reporting almost the same sequence of steps when the process is cancelled, errored out or completed successfully. Now reporting cancelling and failed states on UI. Also added a popup to cancel the process when previously clicking back would abruptly cancel the process.