### PR TITLE
Let the UI behave properly when processes are started from MB print o…

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -70,6 +70,7 @@ class ProcessModel : public BaseModel {
     MODEL_PROP(ProcessStateType, stateType, Loading)
     MODEL_PROP(bool, isBuildPlateClear, false)
     MODEL_PROP(bool, printFileValid, false)
+    MODEL_PROP(int, currentToolIndex, 0)
     MODEL_PROP(int, printPercentage, 0)
     MODEL_PROP(int, timeRemaining, 0)
     MODEL_PROP(int, elapsedTime, 0)

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -145,6 +145,7 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
     }
 
     UPDATE_INT_PROP(printPercentage, proc["progress"]);
+    UPDATE_INT_PROP(currentToolIndex, proc["tool_index"]);
     UPDATE_INT_PROP(timeRemaining, proc["time_remaining"]);
     UPDATE_INT_PROP(elapsedTime, proc["elapsed_time"]);
     activeSet(true);

--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -13,7 +13,7 @@ Item {
     property int currentTemperature: bayID == 1 ? bot.extruderACurrentTemp : bot.extruderBCurrentTemp
     property int targetTempertaure: bayID == 1 ? bot.extruderATargetTemp : bot.extruderBTargetTemp
     property bool filamentBaySwitchActive: false
-    property int bayID: 1
+    property int bayID: bot.process.currentToolIndex + 1
     property int errorCode
     signal processDone
     property int currentState: bot.process.stateType

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -31,7 +31,7 @@ MaterialPageForm {
 
     bay1 {
         loadButton.button_mouseArea.onClicked: {
-            loadUnloadFilamentProcess.bayID = 1
+            startLoadUnloadFromUI = true
             isLoadFilament = true
             enableMaterialDrawer()
             // loadFilament(int tool_index, bool external, bool whilePrinitng)
@@ -50,7 +50,7 @@ MaterialPageForm {
         }
 
         unloadButton.button_mouseArea.onClicked: {
-            loadUnloadFilamentProcess.bayID = 1
+            startLoadUnloadFromUI = true
             isLoadFilament = false
             enableMaterialDrawer()
             // unloadFilament(int tool_index, bool external, bool whilePrinitng)
@@ -73,7 +73,7 @@ MaterialPageForm {
 
     bay2 {
         loadButton.button_mouseArea.onClicked: {
-            loadUnloadFilamentProcess.bayID = 2
+            startLoadUnloadFromUI = true
             isLoadFilament = true
             enableMaterialDrawer()
             // loadFilament(int tool_index, bool external, bool whilePrinitng)
@@ -90,7 +90,7 @@ MaterialPageForm {
         }
 
         unloadButton.button_mouseArea.onClicked: {
-            loadUnloadFilamentProcess.bayID = 2
+            startLoadUnloadFromUI = true
             isLoadFilament = false
             enableMaterialDrawer()
             // unloadFilament(int tool_index, bool external, bool whilePrinitng)

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -16,6 +16,34 @@ Item {
     property alias continue_rectangle: continue_rectangle
     property alias materialPageDrawer: materialPageDrawer
     property bool isLoadFilament: false
+    property bool startLoadUnloadFromUI: false
+    property bool isLoadUnloadProcess: bot.process.type == ProcessType.Load ||
+                                       bot.process.type == ProcessType.Unload
+
+    onIsLoadUnloadProcessChanged: {
+        if(isLoadUnloadProcess && !startLoadUnloadFromUI){
+            if(mainSwipeView.currentIndex != 5){
+                mainSwipeView.swipeToItem(5)
+            }
+            enableMaterialDrawer()
+            if(materialSwipeView.currentIndex != 1){
+                materialSwipeView.swipeToItem(1)
+            }
+            switch(bot.process.type) {
+            case ProcessType.Load:
+                isLoadFilament = true
+                break;
+            case ProcessType.Unload:
+                isLoadFilament = false
+                break;
+            default:
+                break;
+            }
+        }
+        else {
+            startLoadUnloadFromUI = false
+        }
+    }
 
     smooth: false
 

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -24,6 +24,7 @@ Item {
     property alias resetFactoryConfirmPopup: resetFactoryConfirmPopup
     property bool isResetting: false
     property bool hasReset: false
+    property bool isFactoryResetProcess: bot.process.type == ProcessType.FactoryResetProcess
     property bool doneFactoryReset: bot.process.type == ProcessType.FactoryResetProcess &&
                                     bot.process.stateType == ProcessStateType.Done
     property alias wifiPage: wifiPage
@@ -37,7 +38,16 @@ Item {
         interval: 2500
         onTriggered: {
             resetFactoryConfirmPopup.close()
-            mainSwipeView.swipeToItem(0)
+            if(mainSwipeView.currentIndex != 0) {
+                mainSwipeView.swipeToItem(0)
+            }
+        }
+    }
+
+    onIsFactoryResetProcessChanged: {
+        if(isFactoryResetProcess){
+            resetFactoryConfirmPopup.open()
+            isResetting = true
         }
     }
 


### PR DESCRIPTION
…r other client

When processes are started from MB print/repl, move to the correct screen and maintain the correct UI states/variables as if the processes were started through UI. I think these behaviors should be unified at one place in the UI as opposed to being scattered in every processe's file like in this commit, but this will help QA for now which has been testing MB print with the bot. Print process already has the correct behavior no matter where it is started from. This adds load/unload & reset to factory.