### PR TITLE
Cancel, Pause UI tweaks

### DIFF
--- a/src/qml/MoreporkButton.qml
+++ b/src/qml/MoreporkButton.qml
@@ -12,6 +12,7 @@ Button {
     property alias buttonImage: buttonImage
     property color buttonColor: "#00000000"
     property color buttonPressColor: "#0f0f0f"
+    property bool disableButton: false
 
     background: Rectangle {
         opacity: moreporkButton.down ? 1 : 0
@@ -28,6 +29,7 @@ Button {
         anchors.verticalCenter: parent.verticalCenter
         smooth: false
         antialiasing: false
+        opacity: disableButton ? 0.2 : 1
     }
 
     contentItem: Text {
@@ -37,7 +39,7 @@ Button {
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14
-        color: "#ffffff"
+        color: disableButton ? "#545454" : "#ffffff"
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight

--- a/src/qml/PrintIconForm.qml
+++ b/src/qml/PrintIconForm.qml
@@ -75,16 +75,18 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             source: "qrc:/img/loading_gears.png"
             visible: (bot.process.stateType == ProcessStateType.Loading ||
-                      bot.process.stateType == ProcessStateType.Preheating)
+                      bot.process.stateType == ProcessStateType.Preheating ||
+                      bot.process.stateType == ProcessStateType.Cancelling ||
+                      bot.process.stateType == ProcessStateType.CleaningUp ||
+                      bot.process.stateType == ProcessStateType.Done) // Part of cancelling step
 
             RotationAnimator {
-                target: status_image;
+                target: status_image
                 from: 360
                 to: 0
                 duration: 10000
                 loops: Animation.Infinite
-                running: (bot.process.stateType == ProcessStateType.Loading ||
-                          bot.process.stateType == ProcessStateType.Preheating)
+                running: parent.visible
             }
         }
 
@@ -101,7 +103,10 @@ Item {
                       bot.process.stateType == ProcessStateType.Pausing ||
                       bot.process.stateType == ProcessStateType.Resuming ||
                       bot.process.stateType == ProcessStateType.Preheating || // Out of filament
-                      bot.process.stateType == ProcessStateType.UnloadingFilament) // while printing
+                      bot.process.stateType == ProcessStateType.UnloadingFilament || // while printing
+                      bot.process.stateType == ProcessStateType.Cancelling ||
+                      bot.process.stateType == ProcessStateType.CleaningUp || // Part of cancelling step
+                      bot.process.stateType == ProcessStateType.Done) // Part of cancelling step
 
             RotationAnimator {
                 target: loading_or_paused_image;
@@ -109,12 +114,7 @@ Item {
                 to: 360
                 duration: 10000
                 loops: Animation.Infinite
-                running: (bot.process.stateType == ProcessStateType.Loading ||
-                          bot.process.stateType == ProcessStateType.Paused ||
-                          bot.process.stateType == ProcessStateType.Pausing ||
-                          bot.process.stateType == ProcessStateType.Resuming ||
-                          bot.process.stateType == ProcessStateType.Preheating || // Out of filament
-                          bot.process.stateType == ProcessStateType.UnloadingFilament) // while printing
+                running: parent.visible
             }
         }
 

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -103,6 +103,10 @@ Item {
                         case ProcessStateType.Failed:
                             "PRINT FAILED"
                             break;
+                        case ProcessStateType.Cancelling:
+                        case ProcessStateType.CleaningUp:
+                            "CANCELLING"
+                            break;
                         default:
                             ""
                             break;

--- a/src/qml/PrintingDrawer.qml
+++ b/src/qml/PrintingDrawer.qml
@@ -88,6 +88,9 @@ Drawer {
                     }
                 }
                 buttonImage.source: "qrc:/img/pause.png"
+                disableButton:
+                    !(bot.process.stateType == ProcessStateType.Paused ||
+                     bot.process.stateType == ProcessStateType.Printing)
                 buttonColor: "#000000"
                 buttonPressColor: "#0a0a0a"
                 height: 80
@@ -113,14 +116,11 @@ Drawer {
             MoreporkButton {
                 id: buttonChangeFilament
                 buttonText.text: qsTr("CHANGE FILAMENT") + cpUiTr.emptyStr
-                buttonText.color: bot.process.stateType != ProcessStateType.Paused ?
-                                      "#545454" : "#ffffff"
                 buttonImage.source: "qrc:/img/change_filament.png"
-                buttonImage.opacity: bot.process.stateType != ProcessStateType.Paused ?
-                                         0.2 : 1
                 buttonColor: "#000000"
                 buttonPressColor: "#0a0a0a"
                 height: 80
+                disableButton: bot.process.stateType != ProcessStateType.Paused
             }
 
             Rectangle {


### PR DESCRIPTION
1.) Canceling step threw a blank screen before. Now shows appropriate print icon state and canceling text.
2.) Pause print button in pull down drawer is grayed out unless bot is printing or paused.