### PR TITLE
BW-4474-FW 0.48.0.160 QA Bug Fixes

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -70,6 +70,8 @@ class ProcessModel : public BaseModel {
     MODEL_PROP(ProcessType, type, None)
     // 'stateType' is based on the value of params["info"]["current_process"]["step"]
     MODEL_PROP(ProcessStateType, stateType, Loading)
+    MODEL_PROP(bool, isLoadUnloadWhilePaused, false)
+    MODEL_PROP(bool, isLoad, false)
     MODEL_PROP(bool, isBuildPlateClear, false)
     MODEL_PROP(bool, printFileValid, false)
     MODEL_PROP(int, currentToolIndex, 0)

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -141,6 +141,18 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
         isBuildPlateClearReset();
     }
 
+    if(kStepStr == "preheating_loading" ||
+       kStepStr == "preheating_unloading") {
+        isLoadUnloadWhilePausedSet(true);
+
+        kStepStr == "preheating_loading" ?
+                isLoadSet(true) :
+                isLoadSet(false);
+    }
+    else {
+        isLoadUnloadWhilePausedReset();
+    }
+
     const Json::Value &error = proc["error"];
     if (error.isObject()) {
         UPDATE_INT_PROP(errorCode, error["code"]);


### PR DESCRIPTION
Cancel out of load,unload while print paused fixes & get extruder idx correctly for UI.

1.) Loading/Unloading while print paused is cancellable now.
2.) Now looking for tool_index from current process dict. to show on UI during loading/unloading while print paused. In a previous PR (https://github.com/makerbot/morepork-ui/pull/139) to make the bot respond to load/unload process started from 3rd party clients as if started from UI, I clearly forgot that load/unload can also be started while print paused.
https://github.com/makerbot/kaiten/pull/160