### PR TITLE
Scan for networks when moving into wifi page in FRE

### DIFF
--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.10
 import FreStepEnum 1.0
+import WifiStateEnum 1.0
 
 FrePageForm {
     function startTestPrint() {
@@ -34,6 +35,8 @@ FrePageForm {
                 else {
                     inFreStep = true
                     bot.toggleWifi(true)
+                    bot.net.setWifiState(WifiState.Searching)
+                    bot.scanWifi(true)
                     mainSwipeView.swipeToItem(3)
                     settingsPage.settingsSwipeView.swipeToItem(3)
                 }


### PR DESCRIPTION
Was only turning on wifi and not scanning for networks while moving into wifi page in the FRE previously.