### PR TITLE
Get query_status right before moving into the advanced info page...

### DIFF
--- a/src/qml/AdvancedSettingsPage.qml
+++ b/src/qml/AdvancedSettingsPage.qml
@@ -4,6 +4,7 @@ import ProcessStateTypeEnum 1.0
 
 AdvancedSettingsPageForm {
     buttonAdvancedInfo.onClicked: {
+        bot.query_status()
         advancedSettingsSwipeView.swipeToItem(1)
     }
 


### PR DESCRIPTION
...so it doesn't have placeholder values at least for the first time.