### PR TITLE
BW-4690-Don't cancel load on material mismatch

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -29,7 +29,12 @@ Item {
             isMaterialMismatch = false
             isMaterialValid = false
             if(bot.process.type == ProcessType.Load) {
-                materialValidityCheck()
+                if(materialValidityCheck()) {
+                    isMaterialValid = true
+                    if(materialWarningPopup.opened) {
+                        materialWarningPopup.close()
+                    }
+                }
             }
         }
     }
@@ -52,7 +57,7 @@ Item {
             }
         }
         else {
-            bot.acknowledgeMaterial(false)
+            materialWarningPopup.close()
         }
     }
 


### PR DESCRIPTION
Dont cancel loading on material mismatch, which will be problematic during FRE. Instead show a persistent popup to put the correct spool that will only go away when the incorrect spool is removed from the bay. The user can put the correct spool and then proceed normally.