### PR TITLE
increase time to display chached spool info

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -226,7 +226,7 @@ Item {
 
     Timer {
         id: getSpoolInfoTimer
-        interval: 1000
+        interval: 3000
         onTriggered: {
             bot.getSpoolInfo(filamentBayID-1)
         }


### PR DESCRIPTION
When a tag is read by the printer for the first time, the printer will update
the schema version and first load date. After this information is written to
the tag, the local kaiten cache is updated through the filament bay driver, but
UI is displaying the information cached by kaiten before it is completely
updated. This is a temporary fix that fits within our current release schedule.
This timer needs to be removed. Future work will be to have the UI read cached
data from the filament bay driver directly.