### PR TITLE
Unable to update FW to a different versions

### DIFF
--- a/src/qml/FirmwareUpdatePage.qml
+++ b/src/qml/FirmwareUpdatePage.qml
@@ -20,6 +20,7 @@ FirmwareUpdatePageForm {
             break;
         case "firmware_update_failed":
             bot.firmwareUpdateCheck(false)
+            goBack()
             break;
         case "install_from_usb":
             storage.setStorageFileType(StorageFileType.Firmware)

--- a/src/qml/FirmwareUpdatePageForm.qml
+++ b/src/qml/FirmwareUpdatePageForm.qml
@@ -35,6 +35,15 @@ Item {
         }
     }
 
+    property int errorCode
+    property int currentState: bot.process.stateType
+    onCurrentStateChanged: {
+        if(bot.process.errorCode > 0) {
+            errorCode = bot.process.errorCode
+            state = "firmware_update_failed"
+        }
+    }
+
     Rectangle {
         color: "#000000"
         anchors.fill: parent
@@ -288,7 +297,7 @@ Item {
 
             PropertyChanges {
                 target: main_status_text
-                text: "SOFTWARE DOWNLOAD FAILED"
+                text: "SOFTWARE UPDATE FAILED"
                 anchors.topMargin: 20
             }
 
@@ -305,19 +314,12 @@ Item {
 
             PropertyChanges {
                 target: button1
-                label: "TRY AGAIN"
+                label: "OK"
                 buttonWidth: 175
                 visible: true
                 anchors.topMargin: 200
             }
 
-            PropertyChanges {
-                target: button2
-                label: "BACK TO MENU"
-                buttonWidth: 240
-                visible: true
-                anchors.topMargin: 265
-            }
 
             PropertyChanges {
                 target: columnLayout

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -329,6 +329,10 @@ Item {
                             firmwareUpdatePage.state = "install_from_usb"
                         }
                     }
+                    else if (firmwareUpdatePage.state == "firmware_update_failed") {
+                        firmwareUpdatePage.state = "no_firmware_update_available"
+                        settingsSwipeView.swipeToItem(0)
+                    }
                     else {
                         settingsSwipeView.swipeToItem(0)
                     }


### PR DESCRIPTION
- Show update failed screen when there in an error at firmware update process.
- The user needs this feedback when something goes wrong when updating either from MB Print or the UI.