### PR TITLE
Fix filament jam and out of filament UI bugs.

### DIFF
--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -122,8 +122,6 @@ class BotModel : public BaseModel {
     MODEL_PROP(bool, filamentBayBTagVerificationDone, false)
     MODEL_PROP(int, filament1Percent, 0)
     MODEL_PROP(int, filament2Percent, 0)
-    MODEL_PROP(bool, filamentBayAOOF, false)
-    MODEL_PROP(bool, filamentBayBOOF, false)
     MODEL_PROP(bool, topLoadingWarning, false)
     MODEL_PROP(bool, spoolValidityCheckPending, false)
     MODEL_PROP(QString, unknownMaterialWarningType, "None")

--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -106,6 +106,8 @@ class ProcessModel : public BaseModel {
     MODEL_PROP(int, targetHesLower, 3400)
     MODEL_PROP(int, currentHes, 3600)
     MODEL_PROP(int, levelState, 0)
+    MODEL_PROP(bool, filamentBayAOOF, false)
+    MODEL_PROP(bool, filamentBayBOOF, false)
 
   public:
     ProcessModel();

--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -19,7 +19,7 @@ ErrorScreenForm {
         // if load/unload happens while in print process
         // i.e. while print paused, set whilePrinting to true
         if(bot.extruderAJammed ||
-           bot.filamentBayAOOF ||
+           bot.process.filamentBayAOOF ||
            bot.extruderAOOF) {
             bot.loadFilament(0, false, true)
         } else {

--- a/src/qml/ErrorScreenForm.qml
+++ b/src/qml/ErrorScreenForm.qml
@@ -253,9 +253,9 @@ Item {
 
             PropertyChanges {
                 target: errorImage
-                source: bot.filamentBayAOOF ?
+                source: bot.process.filamentBayAOOF ?
                             "qrc:/img/error_oof_bay1.png" :
-                            "qrc:/img/error_oof_bay1.png"
+                            "qrc:/img/error_oof_bay2.png"
             }
 
             PropertyChanges {
@@ -267,7 +267,7 @@ Item {
                 target: errorMessageTitle
                 text: {
                     "PRINT PAUSING\nOUT OF " +
-                    (bot.filamentBayAOOF ?
+                    (bot.process.filamentBayAOOF ?
                          "MODEL" :
                          "SUPPORT") +
                     "\nMATERIAL"
@@ -279,11 +279,11 @@ Item {
                 target: errorMessageDescription
                 text: {
                     "The printer has run out of " +
-                        (bot.filamentBayAOOF ?
+                        (bot.process.filamentBayAOOF ?
                              printPage.print_model_material.toUpperCase() :
-                             printPage.print_model_material.toUpperCase()) +
+                             printPage.print_support_material.toUpperCase()) +
                         ". Open\nmaterial bay " +
-                        (bot.filamentBayAOOF ? "1" : "2") +
+                        (bot.process.filamentBayAOOF ? "1" : "2") +
                         " and carefully pull out\nany material still in the guide tube,\nthen remove the empty material spool.\nThis may take up to 60 seconds."
                 }
             }


### PR DESCRIPTION
UI was displaying wrong filament jam image due to json error parsing bug. Also,
the wrong filament bay out of filament images were being displayed, parsing for
filament bay out of filament was being checked in the incorrect location, and
we were checking for the wrong error code for extruder out of filament. Reduced
duplicate code with macro statements.

https://jira.makerbot.net/browse/BW-4732