### PR TITLE
Cancel load/purge while jammed during test print

### DIFF
--- a/src/qml/LoadUnloadFilament.qml
+++ b/src/qml/LoadUnloadFilament.qml
@@ -1,4 +1,7 @@
 import QtQuick 2.10
+import ProcessTypeEnum 1.0
+import ProcessStateTypeEnum 1.0
+import FreStepEnum 1.0
 
 LoadUnloadFilamentForm {
     acknowledgeButton {
@@ -9,16 +12,31 @@ LoadUnloadFilamentForm {
             else if(state == "unloaded_filament" ||
                state == "loaded_filament") {
                 processDone()
-                if(inFreStep && bayID == 1) {
-                    startLoadUnloadFromUI = true
-                    isLoadFilament = true
-                    bot.loadFilament(1, false, false)
-                    setDrawerState(true)
-                    materialSwipeView.swipeToItem(1)
-                } else if(inFreStep && bayID == 2) {
-                    fre.gotoNextStep(currentFreStep)
-                    mainSwipeView.swipeToItem(0)
-                    inFreStep = false
+                if(inFreStep) {
+                    if(bot.process.type == ProcessType.Print) {
+                        // If user completes load/purge while during
+                        // a print in the FRE they are trying to clear
+                        // jam etc., so the load process should finish
+                        // considering that the printer is still in the
+                        // FRE.
+                        // The processDone() signal handler already
+                        // moves to the print page if we are in a print
+                        // process.
+                    }
+                    else if(bot.process.type == ProcessType.None) {
+                        // During normal load/unload while in FRE
+                        if(bayID == 1) {
+                            startLoadUnloadFromUI = true
+                            isLoadFilament = true
+                            bot.loadFilament(1, false, false)
+                            setDrawerState(true)
+                            materialSwipeView.swipeToItem(1)
+                        } else if(bayID == 2) {
+                            fre.gotoNextStep(currentFreStep)
+                            mainSwipeView.swipeToItem(0)
+                            inFreStep = false
+                        }
+                    }
                 }
             }
             else if(state == "error") {
@@ -40,12 +58,31 @@ LoadUnloadFilamentForm {
 
     retryButton {
         button_mouseArea.onClicked: {
-            if ((state == "loaded_filament") ||
-                    (state == "error" && bot.process.type == ProcessType.Load)) {
-                bot.loadFilament(bayID - 1, false, false);
-            } else if ((state == "unloaded_filament") ||
-                    (state == "error" && bot.process.type == ProcessType.Unload)) {
-                bot.unloadFilament(bayID - 1, false, false);
+            if(state == "loaded_filament") {
+                if(bot.process.type == ProcessType.None) {
+                    bot.loadFilament(bayID - 1, false, false)
+                }
+                else if(bot.process.type == ProcessType.Print) {
+                    bot.loadFilament(bayID - 1, false, true)
+                }
+            } else if(state == "unloaded_filament") {
+                if(bot.process.type == ProcessType.None) {
+                    bot.unloadFilament(bayID - 1, false, false)
+                }
+                else if(bot.process.type == ProcessType.Print) {
+                    bot.unloadFilament(bayID - 1, false, true)
+                }
+            } else if(state == "error") {
+                if(bot.process.type == ProcessType.None) {
+                    isLoadFilament ?
+                        bot.loadFilament(bayID - 1, false, false) :
+                        bot.unloadFilament(bayID - 1, false, false)
+                }
+                else if(bot.process.type == ProcessType.Print) {
+                    isLoadFilament ?
+                        bot.loadFilament(bayID - 1, false, true) :
+                        bot.unloadFilament(bayID - 1, false, true)
+                }
             }
         }
     }

--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
+import FreStepEnum 1.0
 
 Item {
     id: loadUnloadForm
@@ -149,6 +150,10 @@ Item {
                     setDrawerState(false)
                     activeDrawer = printPage.printingDrawer
                     setDrawerState(true)
+                    if(inFreStep &&
+                       bot.process.type == ProcessType.Print) {
+                        mainSwipeView.swipeToItem(1)
+                    }
                 }
                 else {
                     isLoadFilament ? state = "loaded_filament" :
@@ -307,14 +312,14 @@ Item {
 
         RoundedButton {
             id: retryButton
-            label: inFreStep ? "RETRY LOADING" : "RETRY"
-            label_size: acknowledgeButton.label_size
-            buttonWidth: acknowledgeButton.buttonWidth
-            buttonHeight: acknowledgeButton.buttonHeight
-            anchors.left: (inFreStep && bayID == 1) ? acknowledgeButton.left: acknowledgeButton.right
-            anchors.top: (inFreStep && bayID == 1) ? acknowledgeButton.bottom: acknowledgeButton.top
-            anchors.leftMargin: (inFreStep && bayID == 1) ? 0 : 20
-            anchors.topMargin: (inFreStep && bayID == 1) ? 10 : 0
+            label: "RETRY"
+            label_size: 18
+            buttonWidth: 150
+            buttonHeight: 50
+            anchors.left: acknowledgeButton.left
+            anchors.top: acknowledgeButton.bottom
+            anchors.leftMargin: 0
+            anchors.topMargin: 15
             opacity: 0
         }
 
@@ -654,41 +659,96 @@ Item {
                 opacity: 1
                 anchors.topMargin: 20
                 label_width: {
-                    if(bayID == 1 && inFreStep) {
-                        375
-                    } else {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            100
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            if(bayID == 1) {
+                                375
+                            } else if(bayID == 2) {
+                                100
+                            }
+                        }
+                    }
+                    else {
                         100
                     }
                 }
 
                 buttonWidth: {
-                    if(bayID == 1 && inFreStep) {
-                        375
-                    } else {
-                        120
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            100
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            if(bayID == 1) {
+                                375
+                            } else if(bayID == 2) {
+                                100
+                            }
+                        }
+                    }
+                    else {
+                        100
                     }
                 }
 
                 label_size: {
-                    if(bayID == 1 && inFreStep) {
-                        14
-                    } else {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            18
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            if(bayID == 1) {
+                               14
+                            } else if(bayID == 2) {
+                                18
+                            }
+                        }
+                    }
+                    else {
                         18
                     }
                 }
 
                 label: {
-                    if(bayID == 1 && inFreStep) {
-                        "NEXT: LOAD SUPPORT MATERIAL"
-                    } else {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            "DONE"
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            if(bayID == 1) {
+                                "NEXT: LOAD SUPPORT MATERIAL"
+                            } else if(bayID == 2) {
+                                "DONE"
+                            }
+                        }
+                    }
+                    else {
                         "DONE"
                     }
                 }
-
             }
 
             PropertyChanges {
                 target: retryButton
+                label: {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            "RETRY PURGE"
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            "RETRY LOAD"
+                        }
+                    }
+                    else {
+                        "RETRY LOAD"
+                    }
+                }
+                label_size: 18
+                buttonWidth: 200
+                buttonHeight: 50
                 opacity: 1
             }
 
@@ -758,6 +818,23 @@ Item {
 
             PropertyChanges {
                 target: retryButton
+                label: {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            "RETRY UNLOAD"
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            "RETRY UNLOAD"
+                        }
+                    }
+                    else {
+                        "RETRY UNLOAD"
+                    }
+                }
+                label_size: 18
+                label_width: 225
+                buttonWidth: 225
+                buttonHeight: 50
                 opacity: 1
             }
 
@@ -789,15 +866,16 @@ Item {
             PropertyChanges {
                 target: main_instruction_text
                 width: 300
-                text: switch(bot.process.type)
-                      {
+                text: {
+                    switch(bot.process.type) {
                       case ProcessType.Load:
                           "FILAMENT LOADING FAILED"
                           break;
                       case ProcessType.Unload:
                           "FILAMENT UNLOADING FAILED"
                           break;
-                      }
+                    }
+                }
             }
 
             PropertyChanges {
@@ -815,6 +893,23 @@ Item {
 
             PropertyChanges {
                 target: retryButton
+                label: {
+                    if(inFreStep) {
+                        if(bot.process.type == ProcessType.Print) {
+                            isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                        }
+                        else if(bot.process.type == ProcessType.None) {
+                            isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                        }
+                    }
+                    else {
+                        isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                    }
+                }
+                label_size: 18
+                label_width: 225
+                buttonWidth: 225
+                buttonHeight: 50
                 opacity: 1
             }
 

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -58,6 +58,16 @@ MaterialPageForm {
         }
     }
 
+    function resetStatesAfterLoadWhilePaused() {
+        loadUnloadFilamentProcess.state = "base state"
+        materialSwipeView.swipeToItem(0)
+        // If cancelled out of load/unload while in print process
+        // enable print drawer to set UI back to printing state.
+        setDrawerState(false)
+        activeDrawer = printPage.printingDrawer
+        setDrawerState(true)
+    }
+
     bay1 {
         loadButton {
             button_mouseArea.onClicked: {
@@ -197,13 +207,9 @@ MaterialPageForm {
             // current state and it shouldn't actually try cancelling anything
             // and just reset the page state and go back.
             else if(bot.process.stateType == ProcessStateType.Paused) {
-                loadUnloadFilamentProcess.state = "base state"
-                materialSwipeView.swipeToItem(0)
-                // If cancelled out of load/unload while in print process
-                // enable print drawer to set UI back to printing state.
-                setDrawerState(false)
-                activeDrawer = printPage.printingDrawer
-                setDrawerState(true)
+                resetStatesAfterLoadWhilePaused()
+                // Goto the print page
+                mainSwipeView.swipeToItem(1)
             }
         }
         else if(bot.process.type == ProcessType.Load) {
@@ -269,11 +275,20 @@ MaterialPageForm {
 
     materialPageDrawer.buttonCancelMaterialChange.onClicked: {
         materialPageDrawer.close()
-        if(inFreStep) {
-            skipFreStepPopup.open()
-            return;
+        if(!inFreStep) {
+            exitMaterialChange()
         }
-        exitMaterialChange()
+        else {
+            if(bot.process.tyep == ProcessType.Load ||
+               bot.process.type == ProcessType.Unload) {
+                skipFreStepPopup.open()
+            }
+            else {
+                if(bot.process.type == ProcessType.Print) {
+                    cancelLoadUnloadPopup.open()
+                }
+            }
+        }
     }
 
     materialPageDrawer.buttonResume.onClicked: {

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
+import FreStepEnum 1.0
 
 Item {
     id: materialPage
@@ -229,7 +230,15 @@ Item {
                     exitMaterialChange()
                 }
                 else {
-                    skipFreStepPopup.open()
+                    if(bot.process.tyep == ProcessType.Load ||
+                       bot.process.type == ProcessType.Unload) {
+                        skipFreStepPopup.open()
+                    }
+                    else {
+                        if(bot.process.type == ProcessType.Print) {
+                            cancelLoadUnloadPopup.open()
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Rebased https://github.com/makerbot/morepork-ui/pull/201 onto the release branch, original description below:

https://jira.makerbot.net/browse/BW-4739

Selectively cancel the load/purge/unload done to clear a jam during a test print in the FRE instead of skipping the entire test print step and finishing the FRE. This ticket also addresses some issues with the retry button after the load/purge/unload complete screen that was added in recently. It now allows the user to retry the exact last thing they did irrespective of how they came into the load/unload process viz. purge during jam in test print in fre, load during load step in fre, purge during jam in print outside of fre, load outside of fre and the same cases for unload as well and even when erroring out during these.

The initial UX design was to make the user not go outside the print status view at all during the test print in FRE, but after we introduced error handling screen for jam which can happen during the test print, this got a bit complicated now that we are moving between different screens/steps all the while remaining in FRE and maintaining the test print state.