### PR TITLE
BW 4722-Fix declining mat warning while load in FRE to not cancel FRE & other fixes

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -101,6 +101,18 @@ Item {
                                             bay2.filamentMaterialCode
     property string materialName: bayID == 1 ? bay1.filamentMaterialName :
                                                bay2.filamentMaterialName
+
+    function delayedEnableRetryButton() {
+        // Immediately starting the load/unload process
+        // after it completes, presumably while kaiten is
+        // still not fully finished cleaning up, causes it
+        // to not start properly, so disabling the retry
+        // button and then enabling after a few seconds is
+        // a quick hacky fix for this before launch.
+        retryButton.disable_button = true
+        enableRetryButton.start()
+    }
+
     property int errorCode
     signal processDone
     property int currentState: bot.process.stateType
@@ -108,6 +120,7 @@ Item {
         switch(currentState) {
         case ProcessStateType.Stopping:
         case ProcessStateType.Done:
+            delayedEnableRetryButton()
             overrideInvalidMaterial = false
             if(bot.process.errorCode > 0) {
                 errorCode = bot.process.errorCode
@@ -142,6 +155,7 @@ Item {
             // paused state afterwards we also need to monitor
             // the flag there.
             else if(printPage.isPrintProcess) {
+                delayedEnableRetryButton()
                 if(materialChangeCancelled) {
                     state = "base state"
                     materialSwipeView.swipeToItem(0)
@@ -179,6 +193,14 @@ Item {
             break;
         default:
             break;
+        }
+    }
+
+    Timer {
+        id: enableRetryButton
+        interval: 3000
+        onTriggered: {
+            retryButton.disable_button = false
         }
     }
 
@@ -319,7 +341,7 @@ Item {
             anchors.top: acknowledgeButton.bottom
             anchors.leftMargin: 0
             anchors.topMargin: 15
-            opacity: 0
+            visible: false
         }
 
         RowLayout {
@@ -395,7 +417,7 @@ Item {
 
             PropertyChanges {
                 target: retryButton
-                opacity: 0
+                visible: false
             }
 
             PropertyChanges {
@@ -458,7 +480,7 @@ Item {
 
             PropertyChanges {
                 target: retryButton
-                opacity: 0
+                visible: false
             }
 
             PropertyChanges {
@@ -528,7 +550,7 @@ Item {
 
             PropertyChanges {
                 target: retryButton
-                opacity: 0
+                visible: false
             }
         },
         State {
@@ -562,7 +584,7 @@ Item {
 
             PropertyChanges {
                 target: retryButton
-                opacity: 0
+                visible: false
             }
 
             PropertyChanges {
@@ -623,7 +645,7 @@ Item {
 
             PropertyChanges {
                 target: retryButton
-                opacity: 0
+                visible: false
             }
 
             PropertyChanges {
@@ -730,20 +752,20 @@ Item {
                 label: {
                     if(inFreStep) {
                         if(bot.process.type == ProcessType.Print) {
-                            "RETRY PURGE"
+                            "RETRY PURGING"
                         }
                         else if(bot.process.type == ProcessType.None) {
-                            "RETRY LOAD"
+                            "RETRY LOADING"
                         }
                     }
                     else {
-                        "RETRY LOAD"
+                        "RETRY LOADING"
                     }
                 }
                 label_size: 18
-                buttonWidth: 200
+                buttonWidth: 260
                 buttonHeight: 50
-                opacity: 1
+                visible: true
             }
 
             PropertyChanges {
@@ -815,21 +837,21 @@ Item {
                 label: {
                     if(inFreStep) {
                         if(bot.process.type == ProcessType.Print) {
-                            "RETRY UNLOAD"
+                            "RETRY UNLOADING"
                         }
                         else if(bot.process.type == ProcessType.None) {
-                            "RETRY UNLOAD"
+                            "RETRY UNLOADING"
                         }
                     }
                     else {
-                        "RETRY UNLOAD"
+                        "RETRY UNLOADING"
                     }
                 }
                 label_size: 18
-                label_width: 225
-                buttonWidth: 225
+                label_width: 260
+                buttonWidth: 260
                 buttonHeight: 50
-                opacity: 1
+                visible: true
             }
 
             PropertyChanges {
@@ -890,21 +912,21 @@ Item {
                 label: {
                     if(inFreStep) {
                         if(bot.process.type == ProcessType.Print) {
-                            isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                            isLoadFilament ? "RETRY LOADING" : "RETRY UNLOADING"
                         }
                         else if(bot.process.type == ProcessType.None) {
-                            isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                            isLoadFilament ? "RETRY LOADING" : "RETRY UNLOADING"
                         }
                     }
                     else {
-                        isLoadFilament ? "RETRY LOAD" : "RETRY UNLOAD"
+                        isLoadFilament ? "RETRY LOADING" : "RETRY UNLOADING"
                     }
                 }
                 label_size: 18
-                label_width: 225
-                buttonWidth: 225
+                label_width: 260
+                buttonWidth: 260
                 buttonHeight: 50
-                opacity: 1
+                visible: true
             }
 
             PropertyChanges {

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -254,6 +254,10 @@ MaterialPageForm {
         loadUnloadFilamentProcess.state = "base state"
         materialSwipeView.swipeToItem(0)
         setDrawerState(false)
+        if(inFreStep) {
+            mainSwipeView.swipeToItem(0)
+            inFreStep = false
+        }
     }
 
     ok_unk_mat_loading_mouseArea.onClicked: {
@@ -279,7 +283,7 @@ MaterialPageForm {
             exitMaterialChange()
         }
         else {
-            if(bot.process.tyep == ProcessType.Load ||
+            if(bot.process.type == ProcessType.Load ||
                bot.process.type == ProcessType.Unload) {
                 skipFreStepPopup.open()
             }

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -230,8 +230,9 @@ Item {
                     exitMaterialChange()
                 }
                 else {
-                    if(bot.process.tyep == ProcessType.Load ||
-                       bot.process.type == ProcessType.Unload) {
+                    if(bot.process.type == ProcessType.Load ||
+                       bot.process.type == ProcessType.Unload ||
+                       bot.process.type == ProcessType.None) {
                         skipFreStepPopup.open()
                     }
                     else {


### PR DESCRIPTION
Fixes a couple of issues-
1.) Declining the 3rd party material warning popup while loading in FRE will no longer abruptly end the FRE but put the user back in the load material screen of FRE UI.
2.) Fixed a typo in the cancel load popup opening condition check that cause the popup to not open making the process not cancellable through UI.
3.) In my tests the retry button was clicked immediately after the current process ended, the motors were'nt moving in the newly spawned load/unload process presumably because the cleanup process was still running or something to do with PRU? so delaying the retry button by a reasonable time after the process completes ensures the user can only click retry when things are ready. Ran through with Andrew and hopefully is good enough for launch before we get to the root cause of this.