### PR TITLE
BW-4766-Fix back button in set time page to not exit FRE

### DIFF
--- a/src/qml/TimePageForm.qml
+++ b/src/qml/TimePageForm.qml
@@ -22,7 +22,15 @@ Item {
         function swipeToItem(itemToDisplayDefaultIndex) {
             var prevIndex = timeSwipeView.currentIndex
             timeSwipeView.itemAt(itemToDisplayDefaultIndex).visible = true
-            setCurrentItem(timeSwipeView.itemAt(itemToDisplayDefaultIndex))
+            if(itemToDisplayDefaultIndex == 0) {
+                // When we swipe to the 0th index of this page set
+                // the current item as the settings page item that
+                // holds this page since we want the back button to
+                // use the settings item's altBack()
+                setCurrentItem(settingsSwipeView.itemAt(7))
+            } else {
+                setCurrentItem(timeSwipeView.itemAt(itemToDisplayDefaultIndex))
+            }
             timeSwipeView.setCurrentIndex(itemToDisplayDefaultIndex)
             timeSwipeView.itemAt(prevIndex).visible = false
         }


### PR DESCRIPTION
https://jira.makerbot.net/browse/BW-4766

I will be very descriptive while doing pull requests in UI around that topic so that there is some form of verbose documentation for everyone, since there is literally no documentation now.

This fixes the back button in set time page to use the correct altBack() function to determine what to do when the back button is clicked. The UI uses the swipe view component throughout to hold pages. Every item in the swipeview has a backSwiper variable which points to another or the same swipeview and a index variable for that backSwiper. When the back button is clicked from a UI page, the UI uses both those variables to decide which index on what swipeview to swipe to, to go back. We also have a mechanism to overload the back button to look for an altBack() function instead (if it exists) and call that function to go back, so that we can have multiple functionality for the back button depending on the current UI state when trying to go back(eg. inside FRE, process still running etc.).

This fix makes the UI use the altBack() function at the parent swipeview instead of the current child's backSwiper and backSwipeIndex variables.
