### PR TITLE
handle long strings

### DIFF
--- a/src/qml/ExtruderForm.qml
+++ b/src/qml/ExtruderForm.qml
@@ -263,6 +263,10 @@ Item {
                 visible: extruderPresent
                 Text {
                     id: filamentMaterial_text
+                    Layout.maximumWidth: attachButton.width
+                    elide: Text.ElideRight
+                    maximumLineCount: 3
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     text: {
                         if(spoolPresent) {
                             switch(extruderID) {

--- a/src/qml/FileButtonForm.qml
+++ b/src/qml/FileButtonForm.qml
@@ -50,13 +50,14 @@ Button {
 
         Text {
             id: filenameText
+            width: 525
             text: "Filename Text"
             font.family: "Antenna"
             font.letterSpacing: 3
             font.weight: Font.Bold
             font.pointSize: 14
             color: "#ffffff"
-            horizontalAlignment: Text.AlignHCenter
+            horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
             smooth: false

--- a/src/qml/StartPrintPageForm.qml
+++ b/src/qml/StartPrintPageForm.qml
@@ -50,11 +50,13 @@ Item {
                     id: printName
                     width: 330
                     text: file_name
+                    elide: Text.ElideRight
+                    maximumLineCount: 2
                     wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     smooth: false
                     antialiasing: false
                     font.letterSpacing: 3
-                    font.family: "Antennae"
+                    font.family: "Antenna"
                     font.weight: Font.Bold
                     font.pixelSize: 21
                     lineHeight: 1.1
@@ -95,7 +97,7 @@ Item {
                         smooth: false
                         antialiasing: false
                         font.letterSpacing: 3
-                        font.family: "Antennae"
+                        font.family: "Antenna"
                         font.weight: Font.Light
                         font.pixelSize: 18
                         color: "#ffffff"
@@ -116,7 +118,7 @@ Item {
                         smooth: false
                         antialiasing: false
                         font.letterSpacing: 3
-                        font.family: "Antennae"
+                        font.family: "Antenna"
                         font.weight: Font.Light
                         font.pixelSize: 18
                         color: "#ffffff"
@@ -131,7 +133,7 @@ Item {
                     smooth: false
                     antialiasing: false
                     font.letterSpacing: 3
-                    font.family: "Antennae"
+                    font.family: "Antenna"
                     font.weight: Font.Light
                     font.pixelSize: 18
                     color: "#ffffff"
@@ -204,14 +206,20 @@ Item {
 
                 Text {
                     id: fileName_text1
-                    color: "#cbcbcb"
+                    // In a ColumnLayout you must set 'Layout.maximumWidth' not 'width'
+                    Layout.maximumWidth: 330
                     text: file_name
-                    antialiasing: false
+                    elide: Text.ElideRight
+                    maximumLineCount: 2
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     smooth: false
+                    antialiasing: false
                     font.letterSpacing: 3
                     font.family: "Antenna"
                     font.weight: Font.Bold
-                    font.pixelSize: 20
+                    font.pixelSize: 21
+                    lineHeight: 1.1
+                    color: "#cbcbcb"
                 }
 
                 Item {


### PR DESCRIPTION
Material name strings and print file names that were too long would run off the
screen. Enabling Elide for QML text handles this. Also found a few invalid font
name strings.