### PR TITLE
Update the UI's cached time zone when changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Stuff that the morepork build system creates
 /_build*/
 /artifacts/
+/hook_settings.pyc
 
 # Stuff that Qt Creator creates
 /CMakeLists.txt.user

--- a/hook_settings.py
+++ b/hook_settings.py
@@ -1,0 +1,13 @@
+
+import hook_tools
+
+hooks = [
+    #'pre-commit',
+    'prepare-commit-msg'
+]
+
+pre_commit_checks = [
+    hook_tools.cpplint_check,
+    hook_tools.jsonlint_check,
+    hook_tools.cmakelint_check
+]

--- a/src/qml/TimeZoneSelectorForm.qml
+++ b/src/qml/TimeZoneSelectorForm.qml
@@ -59,7 +59,7 @@ Item {
             TimeZoneButton {
                 id: buttonTimeZone_MST
                 timeZoneCode: "MST"
-                timeZoneName: "MOUNTAIN STNADARD TIME"
+                timeZoneName: "MOUNTAIN STANDARD TIME"
                 timeZoneGMTReference: "GMT-7:00"
                 timeZonePathName: "US/Mountain"
             }


### PR DESCRIPTION
BW-4783
http://jira.makerbot.net/browse/BW-4783

This isn't really perfect since it only updates the timezone when changed from
the ui, and we do technicaly expose the time zone change API method to any client.
But the UI is the only client that actually uses this API, so this should be
pretty seamless.  We do have to wait for the response from kaiten indicating that
the timezone has changed, otherwise we don't grab the new value when we ask Qt to
update the time zone.  There may be a way to update the time without going through
the QML layer, but since this is going to very rarely change it does not seem like
a big deal.  Also for some reason the time estimate on a print does not update if
you change the time zone in the middle of a print...

This also fixes a typo and adds git hooks to provide a commit message template (I
also did briefly try to see what happens if the linting hooks were installed, and
the results were not at all surprising.)