### PR TITLE
BW-4801-Change text at print completion

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -111,6 +111,7 @@ class ProcessModel : public BaseModel {
     MODEL_PROP(bool, filamentBayAOOF, false)
     MODEL_PROP(bool, filamentBayBOOF, false)
     MODEL_PROP(bool, cancelled, false)
+    MODEL_PROP(bool, complete, false)
 
   public:
     ProcessModel();

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -258,6 +258,14 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
         cancelledReset();
     }
 
+    const Json::Value &complete = proc["complete"];
+    if(!complete.empty()) {
+        completeSet(proc["complete"].asBool());
+    }
+    else {
+        completeReset();
+    }
+
 
     UPDATE_INT_PROP(timeRemaining, proc["time_remaining"]);
     UPDATE_INT_PROP(elapsedTime, proc["elapsed_time"]);

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -112,7 +112,7 @@ Item {
                             "CANCELLING"
                             break;
                         case ProcessStateType.CleaningUp:
-                            if(timeLeftString == "0M") {
+                            if(bot.process.complete) {
                                 "FINISHING UP"
                             }
                             else {


### PR DESCRIPTION
The earlier method to detect print completion was to look at the print remaining time reach 0. But since most of the complex prints have overestimated times in the .makerbot the UI never showed "FINISHING UP" and always showed "CANCELLING" during the print process cleanup step. Also, this should have been the way it should have been done from the beginning.