### PR TITLE
Add unsuspending_cooling step to UI Loading screen/state for Print Process

### DIFF
--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -47,7 +47,7 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
             kStepStr == "initial_heating" ||
             kStepStr == "final_heating" ||
             kStepStr == "cooling" ||
-            kStepStr == "unsuspending_cooling" ||
+            kStepStr == "cooling_resuming" ||
             kStepStr == "homing" ||
             kStepStr == "position_found" ||
             kStepStr == "preheating_resuming" ||


### PR DESCRIPTION
- Made sure that the UI goes to the same state as the rest of the printprocess when unsuspending_cooling

BW-4597
http://jira.makerbot.net/browse/BW-4597