### PR TITLE
Ask user to run calibration when an extruder is attached

### DIFF
--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -118,6 +118,7 @@ class BotModel : public BaseModel {
     MODEL_PROP(bool, extruderBJammed, false)
     MODEL_PROP(bool, extruderBOOF, false)
     MODEL_PROP(bool, extruderBCalibrated, true)
+    MODEL_PROP(bool, extrudersCalibrated, true)
     MODEL_PROP(int, chamberCurrentTemp, -999)
     MODEL_PROP(int, chamberTargetTemp, -999)
     MODEL_PROP(int, chamberErrorCode, 0)

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -1075,6 +1075,7 @@ void KaitenBotModel::extChangeUpdate(const Json::Value &params) {
             extruderBCalibratedSet(calibrated.asBool());
         }
     }
+    extrudersCalibratedSet(extruderACalibrated() && extruderBCalibrated());
 }
 
 void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -23,8 +23,7 @@ ApplicationWindow {
     property bool extruderBToolTypeCorrect: bot.extruderBToolTypeCorrect
     property bool extruderAPresent: bot.extruderAPresent
     property bool extruderBPresent: bot.extruderBPresent
-    property bool extruderACalibrated: bot.extruderACalibrated
-    property bool extruderBCalibrated: bot.extruderBCalibrated
+    property bool extrudersCalibrated: bot.extrudersCalibrated
     property bool skipAuthentication: false
     property bool isAuthenticated: false
     property bool isBuildPlateClear: bot.process.isBuildPlateClear
@@ -152,16 +151,8 @@ ApplicationWindow {
         }
     }
 
-    onExtruderACalibratedChanged: {
-        if(extruderACalibrated && extruderBCalibrated) {
-            extNotCalibratedPopup.close()
-        }
-        else {
-            extNotCalibratedPopup.open()
-        }
-    }
-    onExtruderBCalibratedChanged: {
-        if(extruderACalibrated && extruderBCalibrated) {
+    onExtrudersCalibratedChanged: {
+        if(extrudersCalibrated) {
             extNotCalibratedPopup.close()
         }
         else {


### PR DESCRIPTION
- Using the "extruder_change" notification sent from kaiten.
  This sends a json message with the extruder index and
  a "calibrated" flag.
- A popup will appear if an extruder requires calibration.