### PR TITLE
Temporarily remove the calibration popup

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -158,7 +158,10 @@ ApplicationWindow {
             extNotCalibratedPopup.close()
         }
         else {
-            extNotCalibratedPopup.open()
+            // For now we don't want users to see this popup because it may be
+            // erroneous and we are having trouble getting people to actually
+            // clean their extruders.
+            // extNotCalibratedPopup.open()
         }
     }
 


### PR DESCRIPTION
Because of the risk of users running calibration with an unclean extruder and
ruining their print quality, we don't want to prompt users to calibrate
extruders that might already be calibrated.  We don't really have reliable
tracking of whether any given set of extruders is calibrated, only whether
calibration has been run at all since the last factory reset, so any logic to
try balance the many competing interests involved in minimizing the number
of users who are printing with bad calibrations is going to be quite complex.
For now we are just going to punt on this by keeping all externally visible
behavior the same as before while turning on the internal tracking.