### PR TITLE
Approve material check when genuine & appropriate material is loaded

### DIFF
--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -46,6 +46,7 @@ PrintPageForm {
             if(print_model_material == "unknown" || materialPage.bay1.isUnknownMaterial) {
                 if(print_model_material == "unknown" && materialPage.bay1.isMaterialValid) {
                     startPrintUnknownSliceGenuineMaterial = true
+                    modelMaterialOK = true
                 } else if(materialPage.bay1.checkSliceValid(print_model_material.toUpperCase()) &&
                           materialPage.bay1.isUnknownMaterial) {
                     startPrintGenuineSliceUnknownMaterial = true


### PR DESCRIPTION
There is a special case in the material check where the slice is for
unknown material but we have genuine material loaded, in which we allow
the user to print under the condition that the other bay does not have any
mismatch i.e. we unconditionally approve the material check for bays
(currently only model bay) if they have genuine and appropriate material
for that bay loaded even if the print file is sliced for unknown material
profile for that bay.

This fixes a bug which caused the check to fail for this special case
since we were just recording this special case and not approving it and
since material mismatch error always has higher precedence over others,
it was thrown to the user since this special case is also technically
a mismatch.

BW-4875
https://jira.makerbot.net/browse/BW-4875