### PR TITLE
Add SR-30 material name

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -173,6 +173,10 @@ Item {
             //PVA-M
             ((filamentVolume * 1.22)/1000).toFixed(3)
             break;
+        case 8:
+            //SR-30
+            ((filamentVolume * 1.1)/1000).toFixed(3)
+            break;
         case 0:
         default:
             0
@@ -202,6 +206,9 @@ Item {
             break;
         case 7:
             "PVA-M"
+            break;
+        case 8:
+            "SR-30"
             break;
         case 0:
         default:

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -468,6 +468,8 @@ void MoreporkStorage::updateMaterialNames(QString &name) {
         name = "tough";
     } else if(name == "pet") {
         name = "petg";
+    } else if(name == "sr30") {
+        name = "sr-30";
     } else if(name == "generic_model") {
         name = "unknown";
     }


### PR DESCRIPTION
Note that this only handles displaying the material name on the UI and not any of
the material check support for this material, which will be added after the specific
'sr30' tool type support is added. Also the trade name for 'sr30' is 'SR-30' which will
be the user facing string.

BW-4887
https://jira.makerbot.net/browse/BW-4887