### PR TITLE
Reset the require material acknowledgement UI flag when cancelling load

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -51,18 +51,19 @@ Item {
                                        bay2.spoolDetailsReady
 
     onIsSpoolDetailsReadyChanged: {
-        if(isSpoolDetailsReady) {
-            if(bot.process.type == ProcessType.Load) {
-                if(materialValidityCheck()) {
+        if(bot.process.type == ProcessType.Load) {
+            if(isSpoolDetailsReady) {
+                if(isSpoolValidityCheckPending &&
+                    materialValidityCheck()) {
                     bot.acknowledgeMaterial(true)
                 } else {
                     isMaterialValid = false
                 }
             }
-        }
-        else {
-            isMaterialValid = false
-            materialWarningPopup.close()
+            else {
+                isMaterialValid = false
+                materialWarningPopup.close()
+            }
         }
     }
 

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -213,6 +213,7 @@ MaterialPageForm {
             }
         }
         else if(bot.process.type == ProcessType.Load) {
+            bot.acknowledgeMaterial(false)
             materialChangeCancelled = true
             bot.cancel()
             loadUnloadFilamentProcess.state = "base state"

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
 import FreStepEnum 1.0
+import ExtruderTypeEnum 1.0
 
 Item {
     id: materialPage
@@ -690,16 +691,36 @@ Item {
                 Text {
                     id: description_text_mat_warning_popup
                     color: "#cbcbcb"
-                    text: isMaterialMismatch ?
-                              (loadUnloadFilamentProcess.currentActiveTool == 1 ?
-                                  qsTr("Only model materials PLA, Tough and PETG are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.") :
-                                  qsTr("Currently only support material such as PVA are compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")) :
-                                  qsTr("The limited warranty included with this 3D printer does not\n" +
-                                  "apply to damage caused by the use of materials not certified\n" +
-                                  "or approved by MakerBot. For additional information, please\n" +
-                                  "visit MakerBot.com/legal/warranty.\n" +
-                                  "Custom settings in MakerBot Print software are required to\n" +
-                                  "configure and use this material.")
+                    text: {
+                        if(isMaterialMismatch) {
+                            if(loadUnloadFilamentProcess.currentActiveTool == 1) {
+                                switch (bot.extruderAType) {
+                                case ExtruderType.MK14:
+                                    qsTr("Only model materials PLA, Tough and PETG are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    break;
+                                case ExtruderType.MK14_HOT:
+                                    qsTr("Only model material ABS is compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    break;
+                                }
+                            } else if(loadUnloadFilamentProcess.currentActiveTool == 2) {
+                                switch (bot.extruderBType) {
+                                case ExtruderType.MK14:
+                                    qsTr("Only support material PVA is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
+                                    break;
+                                case ExtruderType.MK14_HOT:
+                                    qsTr("Only support material SR-30 is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
+                                    break;
+                                }
+                            }
+                        } else {
+                            qsTr("The limited warranty included with this 3D printer does not\n" +
+                            "apply to damage caused by the use of materials not certified\n" +
+                            "or approved by MakerBot. For additional information, please\n" +
+                            "visit MakerBot.com/legal/warranty.\n" +
+                            "Custom settings in MakerBot Print software are required to\n" +
+                            "configure and use this material.")
+                        }
+                    }
                     horizontalAlignment: Text.AlignHCenter
                     Layout.fillWidth: true
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter


### PR DESCRIPTION
Whenever loading process starts kaiten sends a material validity check
notification to all clients that they can use as a trigger to display
popups to user or even try to acknowledge the material themselves. This
fixes a bug where the UI flag that gets set when the notification is
received (which also opens the acknowledge popup) wasn't being reset
when the loading itself is cancelled. Since the flag maintained it's
state from the previous acknowledge notification it wasn't changing state
in subsequent loadings upon receiving the notification thereby not opening
the acknowledge popup.

Also added text in the mismatch popup reflecting the supported materials
depending on the extruders installed.

BW-4907
https://jira.makerbot.net/browse/BW-4907