### PR TITLE
Add CJK fonts, remove unused fonts, use dynamic loading for fonts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 *.m4v filter=lfs diff=lfs merge=lfs -text
 *.mov filter=lfs diff=lfs merge=lfs -text
 *.otf filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
 *.ts filter=lfs diff=lfs merge=lfs -text
 *.qm filter=lfs diff=lfs merge=lfs -text=false
 *.gif filter=lfs diff=lfs merge=lfs -text

--- a/fonts/Antenna-Black.otf
+++ b/fonts/Antenna-Black.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59ff78792d665866772b97b8c0f5e0fe9baff1bd806cc67792e56b02b888bdc5
-size 43916

--- a/fonts/Antenna-BlackItalic.otf
+++ b/fonts/Antenna-BlackItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26a0732a1d8eb70d4349d81308d1e199322a9803fba42adc7b0f8eee180b4583
-size 46104

--- a/fonts/Antenna-BoldItalic.otf
+++ b/fonts/Antenna-BoldItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ede22c01fa554d60086d58bec62d8795c3706e2bdc0d19b9b2a2cd8ac52a23da
-size 51028

--- a/fonts/Antenna-ExtraLight.otf
+++ b/fonts/Antenna-ExtraLight.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7f1f46d842980eaa4617dea575c07a0e2b4596b803c0a009e10cb2d83560c87
-size 48288

--- a/fonts/Antenna-ExtraLightItal.otf
+++ b/fonts/Antenna-ExtraLightItal.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9891fa550bbe2d23a2ec163b0833af156f0b0e5da0140a88b5b98425e6634b
-size 33008

--- a/fonts/Antenna-ExtraLightItalic.otf
+++ b/fonts/Antenna-ExtraLightItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98683ece2a8e494ed2739235f9916e1c8bf5ea8d3b1393e98ff84365cc9c6d00
-size 51056

--- a/fonts/Antenna-LightItalic.otf
+++ b/fonts/Antenna-LightItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d4484aace31a587a2c54aedde9f4d5b7791f34e96464a5a22a4e6e1bea43d7a
-size 50628

--- a/fonts/Antenna-Medium.otf
+++ b/fonts/Antenna-Medium.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:943843905d586739aad67c3df18c2f12df4a4a7cb4b4cf13ce56b4b65a461043
-size 48308

--- a/fonts/Antenna-MediumItalic.otf
+++ b/fonts/Antenna-MediumItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3e030a65d08401ec0b44747c21cc556d72e4a1fd0b77f9b3551e1e2f310dc88
-size 51048

--- a/fonts/Antenna-Regular.otf
+++ b/fonts/Antenna-Regular.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1659f016aebe6279cc33ad51269c341a5c9e82ee5917f1a7bcd55d84dbf0f10
-size 48352

--- a/fonts/Antenna-RegularItalic.otf
+++ b/fonts/Antenna-RegularItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b1988f751a2be1593bed5c36829ada6c629577a2b17f612ec3df7af69a7bc05
-size 51044

--- a/fonts/Antenna-Thin.otf
+++ b/fonts/Antenna-Thin.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30047aae7c0e3bbea6d209c880980b55313b57757d4fa1f304b97717f0158267
-size 45708

--- a/fonts/Antenna-ThinItalic.otf
+++ b/fonts/Antenna-ThinItalic.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c6d031c78bbbc8ba290923d00bd6a61547bf5e981b9f443b1f5396101e73b08
-size 47460

--- a/fonts/NotoSans-Bold.ttf
+++ b/fonts/NotoSans-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c15ac396d2ce6bc33a3b4efacdbd322c9e46376599a725c6f790d8036052cab
+size 455164

--- a/fonts/NotoSans-Light.ttf
+++ b/fonts/NotoSans-Light.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:539961bfcb5dd4257bfd62edfd754e5a9b303f6c535984c63d1d15e39e8f57a5
+size 443040

--- a/fonts/NotoSansArabic-Bold.ttf
+++ b/fonts/NotoSansArabic-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:271746fe8d246837eeb8a43aae0a8d0f3b2e28cc10aa516121bc2c4e41d281d8
+size 199392

--- a/fonts/NotoSansArabic-Light.ttf
+++ b/fonts/NotoSansArabic-Light.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dacb099e297d6e54ad284ae38a65dfeaf7010fa22d072eb00572057c44b3c94f
+size 181564

--- a/fonts/NotoSansCJK-Bold-subset.otf
+++ b/fonts/NotoSansCJK-Bold-subset.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e6ac7aaa6c1ce95d614dd6b5016c1ca235da3d3eb7bf490b7bf9a2eab446bc
+size 13257312

--- a/fonts/NotoSansCJK-Light-subset.otf
+++ b/fonts/NotoSansCJK-Light-subset.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74de55825b2070092c5a65bf72976f0d6294e4dc9c3fead47aaf6be3b13dbcee
+size 12630468

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,8 @@ int main(int argc, char ** argv) {
 #ifdef MOREPORK_UI_QT_CREATOR_BUILD
     QDirIterator it(MOREPORK_ROOT_DIR "/fonts");
     while(it.hasNext()) {
-        if(QFileInfo(it.next()).suffix() == "otf") {
+        if(QFileInfo(it.next()).suffix() == "otf" ||
+           QFileInfo(it.next()).suffix() == "ttf") {
             QFontDatabase::addApplicationFont(it.fileInfo().absoluteFilePath());
         }
     }

--- a/src/qml/AdvancedInfoChamberItemForm.qml
+++ b/src/qml/AdvancedInfoChamberItemForm.qml
@@ -18,7 +18,7 @@ Item {
             font.letterSpacing: 2
             font.weight: Font.Bold
             font.pixelSize: 20
-            font.family: "Antennae"
+            font.family: defaultFont.name
             color: "#ffffff"
         }
 

--- a/src/qml/AdvancedInfoElementForm.qml
+++ b/src/qml/AdvancedInfoElementForm.qml
@@ -16,7 +16,7 @@ Item {
         font.letterSpacing: 2
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 15
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#c9c9c9"
     }
 
@@ -30,7 +30,7 @@ Item {
         anchors.leftMargin: 25
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 15
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#ffffff"
     }
 }

--- a/src/qml/AdvancedInfoFilamentBayElementForm.qml
+++ b/src/qml/AdvancedInfoFilamentBayElementForm.qml
@@ -26,7 +26,7 @@ Item {
             text: qsTr("FILAMENT BAY LABEL")
             font.letterSpacing: 2
             font.pixelSize: 15
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             color: "#ffffff"
         }

--- a/src/qml/AdvancedInfoFilamentBaysItemForm.qml
+++ b/src/qml/AdvancedInfoFilamentBaysItemForm.qml
@@ -16,7 +16,7 @@ Item {
             font.letterSpacing: 2
             font.weight: Font.Bold
             font.pixelSize: 20
-            font.family: "Antennae"
+            font.family: defaultFont.name
             color: "#ffffff"
         }
 

--- a/src/qml/AdvancedInfoMiscItemForm.qml
+++ b/src/qml/AdvancedInfoMiscItemForm.qml
@@ -12,7 +12,7 @@ Item {
         font.letterSpacing: 2
         font.weight: Font.Bold
         font.pixelSize: 20
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#ffffff"
     }
 

--- a/src/qml/AdvancedInfoMotionStatusElementForm.qml
+++ b/src/qml/AdvancedInfoMotionStatusElementForm.qml
@@ -16,7 +16,7 @@ Item {
         font.letterSpacing: 2
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 15
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#c9c9c9"
     }
 
@@ -30,7 +30,7 @@ Item {
         anchors.leftMargin: 70
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 15
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#ffffff"
     }
 
@@ -43,7 +43,7 @@ Item {
         font.pixelSize: 15
         font.capitalization: Font.AllUppercase
         anchors.leftMargin: 70
-        font.family: "Antennae"
+        font.family: defaultFont.name
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: enabled_value.right
     }
@@ -57,7 +57,7 @@ Item {
         font.pixelSize: 15
         font.capitalization: Font.AllUppercase
         anchors.leftMargin: 70
-        font.family: "Antennae"
+        font.family: defaultFont.name
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: endstop_value.right
     }

--- a/src/qml/AdvancedInfoMotionStatusItemForm.qml
+++ b/src/qml/AdvancedInfoMotionStatusItemForm.qml
@@ -18,7 +18,7 @@ Item {
             font.letterSpacing: 2
             font.weight: Font.Bold
             font.pixelSize: 20
-            font.family: "Antennae"
+            font.family: defaultFont.name
             color: "#ffffff"
         }
 

--- a/src/qml/AdvancedInfoToolheadElementForm.qml
+++ b/src/qml/AdvancedInfoToolheadElementForm.qml
@@ -28,7 +28,7 @@ Item {
             text: qsTr("TOOLHEAD LABEL")
             font.letterSpacing: 2
             font.pixelSize: 15
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             color: "#ffffff"
         }

--- a/src/qml/AdvancedInfoToolheadsItemForm.qml
+++ b/src/qml/AdvancedInfoToolheadsItemForm.qml
@@ -16,7 +16,7 @@ Item {
             font.letterSpacing: 2
             font.weight: Font.Bold
             font.pixelSize: 20
-            font.family: "Antennae"
+            font.family: defaultFont.name
             color: "#ffffff"
         }
 

--- a/src/qml/AdvancedSettingsPageForm.qml
+++ b/src/qml/AdvancedSettingsPageForm.qml
@@ -421,7 +421,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -461,7 +461,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -500,7 +500,7 @@ Item {
                     text: hasReset ? qsTr("RESET SUCCESSFUL") : isResetting ? qsTr("RESETTING TO FACTORY...") : qsTr("RESET TO FACTORY")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -515,7 +515,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                     visible: !hasReset

--- a/src/qml/AssistedLevelingForm.qml
+++ b/src/qml/AssistedLevelingForm.qml
@@ -91,7 +91,7 @@ Item {
                 anchors.left: parent.left
                 anchors.leftMargin: 0
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.3
@@ -107,7 +107,7 @@ Item {
                 anchors.left: parent.left
                 anchors.leftMargin: 0
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 18
                 font.weight: Font.Light
                 text: qsTr("Assisted leveling will check your build platform and prompt you to make any adjustments.")
@@ -148,7 +148,7 @@ Item {
             anchors.leftMargin: 75
             wrapMode: Text.WordWrap
             color: "#e6e6e6"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 22
             font.weight: Font.Bold
             lineHeight: 1.2
@@ -160,7 +160,7 @@ Item {
             width: 350
             wrapMode: Text.WordWrap
             color: "#e6e6e6"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 18
             font.weight: Font.Light
             text: qsTr("PROCESS DESCRIPTION")
@@ -185,7 +185,7 @@ Item {
             Text {
                 id: extruder_A_current_temperature_text
                 text: qsTr("%1C").arg(bot.extruderACurrentTemp)
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -202,7 +202,7 @@ Item {
             Text {
                 id: extruder_A_target_temperature_text
                 text: qsTr("50C")
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -217,7 +217,7 @@ Item {
             Text {
                 id: extruder_B_current_temperature_text
                 text: qsTr("%1C").arg(bot.extruderBCurrentTemp)
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -234,7 +234,7 @@ Item {
             Text {
                 id: extruder_B_target_temperature_text
                 text: qsTr("50C")
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -261,7 +261,7 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
             color: "#ffffff"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 18
             font.weight: Font.Light
         }
@@ -307,7 +307,7 @@ Item {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 font.pixelSize: 18
                 font.weight: Font.Bold
-                font.family: "Antennae"
+                font.family: defaultFont.name
             }
 
             Text {
@@ -319,7 +319,7 @@ Item {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 font.pixelSize: 18
                 font.weight: Font.Bold
-                font.family: "Antennae"
+                font.family: defaultFont.name
             }
 
             Text {
@@ -332,7 +332,7 @@ Item {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 font.pixelSize: 18
                 font.weight: Font.Bold
-                font.family: "Antennae"
+                font.family: defaultFont.name
             }
         }
 
@@ -888,7 +888,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -924,7 +924,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -959,7 +959,7 @@ Item {
                     text: qsTr("CANCEL ASSISTED LEVELING")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -973,7 +973,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                 }

--- a/src/qml/BodyText.qml
+++ b/src/qml/BodyText.qml
@@ -3,7 +3,7 @@ import QtQuick 2.7
 Text {
     wrapMode: Text.WordWrap
     color: "#e6e6e6"
-    font.family: "Antennae"
+    font.family: defaultFont.name
     font.pixelSize: 18
     font.weight: Font.Light
     lineHeight: 1.3

--- a/src/qml/BulletedListItemForm.qml
+++ b/src/qml/BulletedListItemForm.qml
@@ -30,7 +30,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: 2
                 font.pixelSize: 14
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 smooth: false
                 antialiasing: false
             }
@@ -46,7 +46,7 @@ Item {
         anchors.leftMargin: 36
         color: "#ffffff"
         font.pixelSize: 19
-        font.family: "Antennae"
+        font.family: defaultFont.name
         font.weight: Font.Light
         smooth: false
         antialiasing: false

--- a/src/qml/ErrorScreenForm.qml
+++ b/src/qml/ErrorScreenForm.qml
@@ -155,7 +155,7 @@ Item {
                 anchors.top: parent.top
                 anchors.topMargin: 65
                 font.bold: true
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.weight: Font.Bold
                 font.pixelSize: 26
                 font.letterSpacing: 2
@@ -170,7 +170,7 @@ Item {
                 text: qsTr("Error description")
                 anchors.top: errorMessageTitle.bottom
                 anchors.topMargin: 20
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 18
                 lineHeight: 1.2
                 color: "#e8e8e8"

--- a/src/qml/ExtruderForm.qml
+++ b/src/qml/ExtruderForm.qml
@@ -114,7 +114,7 @@ Item {
                 antialiasing: false
                 smooth: false
                 color: "#ffffff"
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.weight: Font.Bold
                 font.pixelSize: 36
             }
@@ -145,7 +145,7 @@ Item {
                 antialiasing: false
                 smooth: false
                 color: "#ffffff"
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.weight: Font.Bold
                 font.pixelSize: 16
             }
@@ -174,7 +174,7 @@ Item {
                         smooth: false
                         color: "#cbcbcb"
                         font.letterSpacing: 2
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 13
                     }
@@ -186,7 +186,7 @@ Item {
                         smooth: false
                         color: "#cbcbcb"
                         font.letterSpacing: 2
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 13
                     }
@@ -211,7 +211,7 @@ Item {
                         smooth: false
                         color: "#cbcbcb"
                         font.letterSpacing: 2
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 13
                     }
@@ -225,7 +225,7 @@ Item {
                         smooth: false
                         color: "#cbcbcb"
                         font.letterSpacing: 2
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 13
                     }
@@ -292,7 +292,7 @@ Item {
                     smooth: false
                     color: "#ffffff"
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 16
                     lineHeight: 1.6

--- a/src/qml/ExtruderPageForm.qml
+++ b/src/qml/ExtruderPageForm.qml
@@ -184,7 +184,7 @@ Item {
                     anchors.left: handle_top_lid_image.right
                     anchors.leftMargin: 50
                     font.letterSpacing: 2
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 21
                     lineHeight: 1.2
@@ -284,7 +284,7 @@ Item {
                         anchors.top: parent.top
                         anchors.topMargin: 50
                         font.letterSpacing: 2
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 21
                         lineHeight: 1.2
@@ -298,7 +298,7 @@ Item {
                         text: ""
                         anchors.top: main_instruction_text.bottom
                         anchors.topMargin: 25
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 18
                         lineHeight: 1.1
@@ -359,7 +359,7 @@ Item {
                             color: "#ffffff"
                             anchors.verticalCenter: parent.verticalCenter
                             font.pixelSize: 16
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             smooth: false
                             antialiasing: false
                         }

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -274,7 +274,7 @@ Item {
                                               12 : 0
             font.capitalization: Font.AllUppercase
             font.letterSpacing: 4
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 18
             smooth: false
@@ -299,7 +299,7 @@ Item {
                 text: qsTr("MATERIAL BAY %1").arg(filamentBayID)
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                 font.letterSpacing: 5
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.weight: Font.Bold
                 font.pixelSize: 20
                 smooth: false
@@ -330,7 +330,7 @@ Item {
                     }
                     font.capitalization: Font.AllUppercase
                     font.letterSpacing: 4
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pixelSize: 18
                     smooth: false
@@ -362,7 +362,7 @@ Item {
                             qsTr("%1KG REMAINING").arg(filamentQuantity) :
                             ""
                     font.letterSpacing: 4
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pixelSize: 18
                     smooth: false
@@ -423,7 +423,7 @@ Item {
             anchors.topMargin: 0
             color: "#ffffff"
             font.pixelSize: 15
-            font.family: "Antennae"
+            font.family: defaultFont.name
         }
 
         Text {
@@ -435,7 +435,7 @@ Item {
             anchors.topMargin: 0
             color: "#ffffff"
             font.pixelSize: 15
-            font.family: "Antennae"
+            font.family: defaultFont.name
         }
     }
 }

--- a/src/qml/FileButtonForm.qml
+++ b/src/qml/FileButtonForm.qml
@@ -52,7 +52,7 @@ Button {
             id: filenameText
             width: 525
             text: qsTr("Filename Text")
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 3
             font.weight: Font.Bold
             font.pointSize: 14
@@ -75,7 +75,7 @@ Button {
             Text {
                 id: filePrintTime
                 text: qsTr("File Print Time")
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.letterSpacing: 3
                 font.weight: Font.Light
                 font.pointSize: 12
@@ -98,7 +98,7 @@ Button {
                 id: fileMaterial
                 text: qsTr("File Material")
                 font.capitalization: Font.AllUppercase
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.letterSpacing: 3
                 font.weight: Font.Light
                 font.pointSize: 12

--- a/src/qml/FirmwareFileListUsbForm.qml
+++ b/src/qml/FirmwareFileListUsbForm.qml
@@ -36,7 +36,7 @@ Item {
 
     Text {
         color: "#ffffff"
-        font.family: "Antennae"
+        font.family: defaultFont.name
         font.weight: Font.Light
         text: qsTr("No Firmware Files Found")
         anchors.horizontalCenter: parent.horizontalCenter
@@ -171,7 +171,7 @@ Item {
                        Layout.fillWidth: false
                        font.letterSpacing: 3
                        font.weight: Font.Bold
-                       font.family: "Antennae"
+                       font.family: defaultFont.name
                        font.pixelSize: 18
                        anchors.verticalCenter: parent.verticalCenter
                        anchors.horizontalCenter: parent.horizontalCenter
@@ -211,7 +211,7 @@ Item {
                     text: qsTr("COPYING FIRMWARE")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -234,7 +234,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                     visible: true

--- a/src/qml/FirmwareUpdatePageForm.qml
+++ b/src/qml/FirmwareUpdatePageForm.qml
@@ -91,7 +91,7 @@ Item {
             wrapMode: Text.WordWrap
             font.letterSpacing: 3
             color: "#cbcbcb"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.capitalization: Font.AllUppercase
             font.pixelSize: 20
@@ -108,7 +108,7 @@ Item {
             font.wordSpacing: 1
             font.letterSpacing: 2
             color: "#cbcbcb"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 18
             lineHeight: 1.35
@@ -120,7 +120,7 @@ Item {
             id: release_notes_text
             text: qsTr("RELEASE NOTES")
             color: "#cbcbcb"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.underline: true
             font.capitalization: Font.AllUppercase

--- a/src/qml/FirmwareUpdateSuccessfulScreenForm.qml
+++ b/src/qml/FirmwareUpdateSuccessfulScreenForm.qml
@@ -35,7 +35,7 @@ Item {
             font.letterSpacing: 2
             anchors.top: parent.top
             anchors.topMargin: 35
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.pixelSize: 22
             lineHeight: 1.3

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -42,7 +42,7 @@ Item {
             font.letterSpacing: 2
             anchors.top: parent.top
             anchors.topMargin: 35
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.pixelSize: 28
             lineHeight: 1.2
@@ -54,7 +54,7 @@ Item {
             text: qsTr("Follow these steps to set up your\nMethod Performance 3D Printer.")
             anchors.top: title_text.bottom
             anchors.topMargin: 20
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 20
             lineHeight: 1.3
@@ -129,7 +129,7 @@ Item {
                     anchors.top: parent.bottom
                     anchors.topMargin: 18
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 14
                 }
@@ -151,7 +151,7 @@ Item {
                     anchors.top: parent.bottom
                     anchors.topMargin: 18
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 14
                 }
@@ -173,7 +173,7 @@ Item {
                     anchors.top: parent.bottom
                     anchors.topMargin: 18
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 14
                 }
@@ -195,7 +195,7 @@ Item {
                     anchors.top: parent.bottom
                     anchors.topMargin: 18
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 14
                 }
@@ -217,7 +217,7 @@ Item {
                     anchors.top: parent.bottom
                     anchors.topMargin: 18
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 14
                 }

--- a/src/qml/InfoItemForm.qml
+++ b/src/qml/InfoItemForm.qml
@@ -23,7 +23,7 @@ Item {
             smooth: false
             anchors.left: parent.left
             anchors.leftMargin: 0
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.letterSpacing: 3
             font.pixelSize: 18
@@ -39,7 +39,7 @@ Item {
             anchors.leftMargin: 350
             antialiasing: false
             smooth: false
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 5
             font.weight: Font.Bold
             font.pixelSize: 18

--- a/src/qml/InfoPageForm.qml
+++ b/src/qml/InfoPageForm.qml
@@ -24,7 +24,7 @@ Item {
             font.pixelSize: 22
             font.capitalization: Font.AllUppercase
             color: "#cbcbcb"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.letterSpacing: 5
         }
@@ -88,7 +88,7 @@ Item {
                     delegate:
                         Text {
                         text: model.modelData
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.letterSpacing: 2
                         font.weight: Font.Bold
                         font.pixelSize: 18

--- a/src/qml/LanguageButtonForm.qml
+++ b/src/qml/LanguageButtonForm.qml
@@ -69,7 +69,7 @@ Button {
         anchors.left: parent.left
         anchors.leftMargin: 120
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 2
         font.weight: Font.Bold
         font.pointSize: 14

--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -279,7 +279,7 @@ Item {
             anchors.topMargin: 100
             font.letterSpacing: 4
             wrapMode: Text.WordWrap
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.pixelSize: 20
             lineHeight: 1.3
@@ -321,7 +321,7 @@ Item {
             anchors.top: main_instruction_text.bottom
             anchors.topMargin: 30
             wrapMode: Text.WordWrap
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 18
             lineHeight: 1.35
@@ -363,7 +363,7 @@ Item {
             Text {
                 id: extruder_current_temperature_text
                 text: qsTr("%1C").arg(currentTemperature)
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -380,7 +380,7 @@ Item {
             Text {
                 id: extruder_target_temperature_text
                 text: qsTr("%1C").arg(targetTemperature)
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light

--- a/src/qml/MainMenuIconForm.qml
+++ b/src/qml/MainMenuIconForm.qml
@@ -46,7 +46,7 @@ Item {
             anchors.topMargin: 130
             antialiasing: false
             smooth: false
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 3
             font.weight: Font.Light
             anchors.horizontalCenter: parent.horizontalCenter

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -381,7 +381,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -417,7 +417,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -452,7 +452,7 @@ Item {
                     text: qsTr("NO EXTRUDER DETECTED")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -470,7 +470,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                 }
@@ -567,7 +567,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -606,7 +606,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -643,7 +643,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -682,7 +682,7 @@ Item {
                                   qsTr("UNKNOWN MATERIAL WARNING")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -705,7 +705,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 20
                     lineHeight: 1.4
                 }
@@ -795,7 +795,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -831,7 +831,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -867,7 +867,7 @@ Item {
                                            qsTr("CANCEL MATERIAL UNLOADING?")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -882,7 +882,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                 }
@@ -943,7 +943,7 @@ Item {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 font.weight: Font.Light
                 wrapMode: Text.WordWrap
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 18
                 lineHeight: 1.3
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/src/qml/MenuButtonForm.qml
+++ b/src/qml/MenuButtonForm.qml
@@ -49,7 +49,7 @@ Button {
         Text {
             id: buttonText
             text: "Default Text"
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 3
             font.weight: Font.Bold
             font.pointSize: 14

--- a/src/qml/ModalPopupForm.qml
+++ b/src/qml/ModalPopupForm.qml
@@ -116,7 +116,7 @@ Popup {
                     Layout.fillWidth: false
                     font.letterSpacing: 3
                     font.weight: Font.Bold
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -152,7 +152,7 @@ Popup {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.letterSpacing: 3
                     font.weight: Font.Bold
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -190,7 +190,7 @@ Popup {
                     Layout.fillWidth: false
                     font.letterSpacing: 3
                     font.weight: Font.Bold
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/src/qml/MoreporkButton.qml
+++ b/src/qml/MoreporkButton.qml
@@ -35,7 +35,7 @@ Button {
     contentItem: Text {
         id: buttonText
         text: qsTr("MoreporkButton Text")
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -255,6 +255,11 @@ ApplicationWindow {
         return (bot.process.type != ProcessType.None)
     }
 
+    FontLoader {
+        id: defaultFont
+        name: "Antenna"
+    }
+
     Item {
         id: rootItem
         smooth: false
@@ -594,7 +599,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -667,7 +672,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -749,7 +754,7 @@ ApplicationWindow {
                         }
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -807,7 +812,7 @@ ApplicationWindow {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         lineHeight: 1.3
                     }
@@ -876,7 +881,7 @@ ApplicationWindow {
                         anchors.topMargin: 0
                         anchors.horizontalCenter: parent.horizontalCenter
                         font.letterSpacing: 5
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 22
                     }
@@ -901,7 +906,7 @@ ApplicationWindow {
                         anchors.top: authImage.bottom
                         horizontalAlignment: Text.AlignLeft
                         font.weight: isAuthenticated ? Font.Bold : Font.Light
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         font.letterSpacing: isAuthenticated ? 3 : 1
                         font.capitalization: isAuthenticated ? Font.AllUppercase : Font.MixedCase
@@ -923,7 +928,7 @@ ApplicationWindow {
                             horizontalAlignment: Text.AlignLeft
                             font.weight: Font.Bold
                             font.capitalization: Font.AllUppercase
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.letterSpacing: 3
                             visible: !isAuthenticated
@@ -936,7 +941,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             horizontalAlignment: Text.AlignLeft
                             font.weight: Font.Light
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.letterSpacing: 1
                             visible: !skipAuthentication
@@ -994,7 +999,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1040,7 +1045,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1130,7 +1135,7 @@ ApplicationWindow {
                         anchors.topMargin: 0
                         anchors.horizontalCenter: parent.horizontalCenter
                         font.letterSpacing: 5
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 22
                     }
@@ -1147,7 +1152,7 @@ ApplicationWindow {
                         anchors.top: install_unsigned_fw_header_text.bottom
                         horizontalAlignment: Text.AlignHCenter
                         font.weight: Font.Light
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         font.letterSpacing: 3
                         font.capitalization: Font.MixedCase
@@ -1204,7 +1209,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1246,7 +1251,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1363,7 +1368,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1410,7 +1415,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1455,7 +1460,7 @@ ApplicationWindow {
                         text: viewReleaseNotes ? qsTr("SOFTWARE %1 RELEASE NOTES").arg(bot.firmwareUpdateVersion) : skipFirmwareUpdate ? qsTr("SKIP SOFTWARE UPDATE?") : qsTr("SOFTWARE UPDATE AVAILABLE")
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 5
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 18
                     }
@@ -1478,7 +1483,7 @@ ApplicationWindow {
                         Layout.fillWidth: true
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         lineHeight: 1.35
                         visible: !viewReleaseNotes
@@ -1506,7 +1511,7 @@ ApplicationWindow {
                                 Layout.fillWidth: true
                                 font.weight: Font.Light
                                 wrapMode: Text.WordWrap
-                                font.family: "Antenna"
+                                font.family: defaultFont.name
                                 font.pixelSize: 18
                                 lineHeight: 1.35
                             }
@@ -1526,7 +1531,7 @@ ApplicationWindow {
                         Layout.fillWidth: true
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         visible: viewReleaseNotes ? false : true
 
@@ -1628,7 +1633,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1674,7 +1679,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1713,7 +1718,7 @@ ApplicationWindow {
                         text: qsTr("CLEAR BUILD PLATE")
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -1727,7 +1732,7 @@ ApplicationWindow {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         lineHeight: 1.3
                     }
@@ -1895,7 +1900,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1928,7 +1933,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -1962,7 +1967,7 @@ ApplicationWindow {
                         anchors.topMargin: 90
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         lineHeight: 1.3
                         text: {
@@ -2089,7 +2094,7 @@ ApplicationWindow {
                         text: qsTr("EXTRUDERS ARE BEING PROGRAMMED...")
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -2179,7 +2184,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2220,7 +2225,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2258,7 +2263,7 @@ ApplicationWindow {
                         text: qsTr("CANCEL PRINT")
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -2272,7 +2277,7 @@ ApplicationWindow {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         lineHeight: 1.3
                     }
@@ -2349,7 +2354,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2388,7 +2393,7 @@ ApplicationWindow {
                         text: qsTr("YOU CAN NOW SAFELY REMOVE THE USB")
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -2531,7 +2536,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2594,7 +2599,7 @@ ApplicationWindow {
                             Layout.fillWidth: false
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2675,7 +2680,7 @@ ApplicationWindow {
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                             font.letterSpacing: 3
                             font.weight: Font.Bold
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
@@ -2767,7 +2772,7 @@ ApplicationWindow {
                         }
                         font.letterSpacing: 3
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Bold
                         font.pixelSize: 20
                     }
@@ -2840,7 +2845,7 @@ ApplicationWindow {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 20
                         lineHeight: 1.35
                     }

--- a/src/qml/NamePrinterPageForm.qml
+++ b/src/qml/NamePrinterPageForm.qml
@@ -64,7 +64,7 @@ Item {
                     anchors.left: nameField.left
                     anchors.bottom: nameField.top
                     anchors.bottomMargin: 10
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                 }
 
@@ -85,7 +85,7 @@ Item {
                             color: "#f7f7f7"
                         }
                     color: "#000000"
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pointSize: 14
                     placeholderText: "My Method Printer"
@@ -166,7 +166,7 @@ Item {
                 Text {
                     id: printer_name_label
                     color: "#ffffff"
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     text: qsTr("PRINTER NAME")
                     anchors.top: parent.top
@@ -178,7 +178,7 @@ Item {
                 Text {
                     id: printer_name_text
                     color: "#ffffff"
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     text: {
                         if(nameField.text == "") {

--- a/src/qml/PreheatPageForm.qml
+++ b/src/qml/PreheatPageForm.qml
@@ -42,7 +42,7 @@ Item {
                     }
                     font.letterSpacing: 3
                     font.weight: Font.Light
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 20
                     anchors.right: parent.right
                     anchors.rightMargin: {

--- a/src/qml/PrintIconForm.qml
+++ b/src/qml/PrintIconForm.qml
@@ -136,7 +136,7 @@ Item {
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
             visible: false
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 75
 
@@ -153,7 +153,7 @@ Item {
                 anchors.rightMargin: -30
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
-                font.family: "Antenna"
+                font.family: defaultFont.name
                 font.weight: Font.Light
                 font.pixelSize: 25
             }

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -367,7 +367,7 @@ Item {
 
             Text {
                 color: "#ffffff"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.weight: Font.Light
                 text: qsTr("No Items")
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -154,7 +154,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.letterSpacing: 5
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 18
                 }
@@ -203,7 +203,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pixelSize: 18
                 }
@@ -248,7 +248,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pixelSize: 18
                     lineHeight: 1.4
@@ -336,7 +336,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -370,7 +370,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -384,7 +384,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -398,7 +398,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -412,7 +412,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -425,7 +425,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -445,7 +445,7 @@ Item {
                             text: qsTr("99.99%")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -458,7 +458,7 @@ Item {
                             text: uses_support_
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -471,7 +471,7 @@ Item {
                             text: uses_raft_
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -484,7 +484,7 @@ Item {
                             text: qsTr("%1 %2").arg(model_mass_).arg(print_model_material_)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -497,7 +497,7 @@ Item {
                             text: qsTr("%1 %2").arg(support_mass_).arg(print_support_material_)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -543,7 +543,7 @@ Item {
                     text: qsTr("%1 INFO").arg(printerName)
                     antialiasing: false
                     smooth: false
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.pixelSize: 20
                     font.weight: Font.Bold
                     font.letterSpacing: 3
@@ -576,7 +576,7 @@ Item {
                             text: qsTr("EX 1 TEMP")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Light
                             font.letterSpacing: 3
@@ -589,7 +589,7 @@ Item {
                             text: qsTr("EX 2 TEMP")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Light
                             font.letterSpacing: 3
@@ -602,7 +602,7 @@ Item {
                             text: qsTr("EX 1 LIFE")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Light
                             font.letterSpacing: 3
@@ -616,7 +616,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.pixelSize: 18
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.wordSpacing: 2
@@ -629,7 +629,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.pixelSize: 18
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.wordSpacing: 2
@@ -649,7 +649,7 @@ Item {
                             text: qsTr("%1C").arg(bot.extruderACurrentTemp)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Bold
                             font.letterSpacing: 3
@@ -661,7 +661,7 @@ Item {
                             text: qsTr("%1C").arg(bot.extruderBCurrentTemp)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Bold
                             font.letterSpacing: 3
@@ -673,7 +673,7 @@ Item {
                             text: qsTr("%1mm").arg(extruderAExtrusionDistance)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Bold
                             font.letterSpacing: 3
@@ -685,7 +685,7 @@ Item {
                             text: qsTr("%1mm").arg(extruderBExtrusionDistance)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Bold
                             font.letterSpacing: 3
@@ -697,7 +697,7 @@ Item {
                             text: qsTr("%1C").arg(bot.chamberCurrentTemp)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.pixelSize: 18
                             font.weight: Font.Bold
                             font.letterSpacing: 3
@@ -729,7 +729,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.pixelSize: 15
                     font.weight: Font.Light
                     font.letterSpacing: 3
@@ -742,7 +742,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.pixelSize: 145
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.letterSpacing: 3
                 }
@@ -754,7 +754,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.pixelSize: 15
                     font.weight: Font.Light
                     font.letterSpacing: 3
@@ -767,7 +767,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.pixelSize: 15
                     font.weight: Font.Bold
                     font.letterSpacing: 3
@@ -799,7 +799,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.pixelSize: 85
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.letterSpacing: 0
 
@@ -812,7 +812,7 @@ Item {
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: -30
                         font.pixelSize: 16
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.letterSpacing: 3
 
@@ -825,7 +825,7 @@ Item {
                             anchors.left: parent.right
                             anchors.leftMargin: 10
                             font.pixelSize: 16
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                         }
@@ -839,7 +839,7 @@ Item {
                             anchors.bottom: parent.bottom
                             anchors.bottomMargin: -30
                             font.pixelSize: 16
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
 
@@ -852,7 +852,7 @@ Item {
                                 anchors.left: parent.right
                                 anchors.leftMargin: 10
                                 font.pixelSize: 16
-                                font.family: "Antenna"
+                                font.family: defaultFont.name
                                 font.weight: Font.Bold
                                 font.letterSpacing: 3
                             }

--- a/src/qml/RaiseLowerBuildPlateItemForm.qml
+++ b/src/qml/RaiseLowerBuildPlateItemForm.qml
@@ -20,7 +20,7 @@ Item {
         anchors.bottomMargin: 50
         anchors.horizontalCenter: row.horizontalCenter
         font.weight: Font.Light
-        font.family: "Antennae"
+        font.family: defaultFont.name
         font.pixelSize: 20
     }
 
@@ -33,7 +33,7 @@ Item {
         anchors.bottom: row.top
         anchors.bottomMargin: 50
         font.weight: Font.Light
-        font.family: "Antennae"
+        font.family: defaultFont.name
         font.pixelSize: 20
     }
 

--- a/src/qml/ReviewTestPrintPageForm.qml
+++ b/src/qml/ReviewTestPrintPageForm.qml
@@ -39,7 +39,7 @@ Item {
             Layout.fillWidth: true
             font.weight: Font.Light
             wrapMode: Text.WordWrap
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 20
             lineHeight: 1.5
             anchors.bottom: parent.bottom

--- a/src/qml/RoundedButtonForm.qml
+++ b/src/qml/RoundedButtonForm.qml
@@ -41,7 +41,7 @@ Rectangle {
         font.capitalization: Font.AllUppercase
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antennae"
+        font.family: defaultFont.name
         color: "#ffffff"
         smooth: false
         antialiasing: false

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -547,7 +547,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -588,7 +588,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -627,7 +627,7 @@ Item {
                     text: deauthorizeAccountsPopup.clearingAccounts ? qsTr("ALL ACCOUNTS DEAUTHORIZED") : qsTr("DEAUTHORIZE ACCOUNTS")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -650,7 +650,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                     visible: !deauthorizeAccountsPopup.clearingAccounts

--- a/src/qml/SignInPageForm.qml
+++ b/src/qml/SignInPageForm.qml
@@ -92,7 +92,7 @@ Item {
                         anchors.left: parent.left
                         anchors.leftMargin: 0
                         color: "#e6e6e6"
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 26
                         font.weight: Font.Bold
                         lineHeight: 1.2
@@ -108,7 +108,7 @@ Item {
                         anchors.left: parent.left
                         anchors.leftMargin: 0
                         color: "#e6e6e6"
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         font.weight: Font.Light
                         text: qsTr("Sign in with your MakerBot Account to add this printer to your printer list. If you do not have a MakerBot Account, please visit MakerBot.com to create an account.")
@@ -171,7 +171,7 @@ Item {
                     anchors.left: usernameTextField.left
                     anchors.bottom: usernameTextField.top
                     anchors.bottomMargin: 12
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                 }
 
@@ -185,7 +185,7 @@ Item {
                     anchors.topMargin: 50
                     anchors.left: parent.left
                     anchors.leftMargin: 50
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pointSize: 14
                     background: Rectangle {
@@ -220,7 +220,7 @@ Item {
                         font.wordSpacing: 1
                         font.pointSize: 12
                         color: "#ffffff"
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         //anchors.left: usernameTextField.left
                     }
@@ -265,7 +265,7 @@ Item {
                     anchors.left: passwordField.left
                     anchors.bottom: passwordField.top
                     anchors.bottomMargin: 10
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                 }
 
@@ -285,7 +285,7 @@ Item {
                         color: "#f7f7f7"
                     }
                     color: "#000000"
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pointSize: (showPassword.checked ||
                                     text == "") ? 14 : 24
@@ -329,7 +329,7 @@ Item {
                         font.wordSpacing: 1
                         font.pointSize: 12
                         color: "#ffffff"
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         anchors.left: showPassword.right
                     }
@@ -344,7 +344,7 @@ Item {
                             font.wordSpacing: 1
                             font.pointSize: 12
                             color: "#ffffff"
-                            font.family: "Antennae"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                         }
 
@@ -401,7 +401,7 @@ Item {
                 font.letterSpacing: 3
                 wrapMode: Text.WordWrap
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.4
@@ -427,7 +427,7 @@ Item {
                 font.letterSpacing: 3
                 wrapMode: Text.WordWrap
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.4
@@ -453,7 +453,7 @@ Item {
                 font.letterSpacing: 3
                 wrapMode: Text.WordWrap
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.2
@@ -489,7 +489,7 @@ Item {
                 font.letterSpacing: 3
                 wrapMode: Text.WordWrap
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.2
@@ -507,7 +507,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 font.weight: Font.Light
                 wrapMode: Text.WordWrap
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 20
                 lineHeight: 1.3
                 visible: true
@@ -539,7 +539,7 @@ Item {
                 font.letterSpacing: 3
                 wrapMode: Text.WordWrap
                 color: "#e6e6e6"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 24
                 font.weight: Font.Bold
                 lineHeight: 1.4
@@ -556,7 +556,7 @@ Item {
                 anchors.bottomMargin: 10
                 font.weight: Font.Light
                 wrapMode: Text.WordWrap
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.pixelSize: 20
                 font.letterSpacing: 1
                 lineHeight: 1.3

--- a/src/qml/SnipMaterialScreenForm.qml
+++ b/src/qml/SnipMaterialScreenForm.qml
@@ -37,7 +37,7 @@ Item {
             text: qsTr("REMOVE BENT MATERIAL")
             font.letterSpacing: 1
             font.wordSpacing: 3
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.pixelSize: 22
             font.weight: Font.Bold
             antialiasing: false
@@ -48,7 +48,7 @@ Item {
             id: description_text
             color: "#cbcbcb"
             text: qsTr("Cleanly cut any material that is bent\nor kinked before inserting it into the\nguide tube. Any kinks can cause the\nmaterial to become jammed in the\ntube.")
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.pixelSize: 20
             font.weight: Font.Light
             lineHeight: 1.3

--- a/src/qml/StartPrintMaterialViewItemForm.qml
+++ b/src/qml/StartPrintMaterialViewItemForm.qml
@@ -124,7 +124,7 @@ Item {
             smooth: false
             antialiasing: false
             font.letterSpacing: 3
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.pixelSize: 17
             color: "#cbcbcb"
@@ -139,7 +139,7 @@ Item {
             smooth: false
             antialiasing: false
             font.letterSpacing: 3
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Bold
             font.pixelSize: 17
             color: "#cbcbcb"
@@ -157,7 +157,7 @@ Item {
             smooth: false
             antialiasing: false
             font.letterSpacing: 3
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Normal
             font.pixelSize: 18
             color: "#cbcbcb"
@@ -179,7 +179,7 @@ Item {
             smooth: false
             antialiasing: false
             font.letterSpacing: 1
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.weight: Font.Light
             font.pixelSize: 18
             color: "#ffffff"

--- a/src/qml/StartPrintPageForm.qml
+++ b/src/qml/StartPrintPageForm.qml
@@ -56,7 +56,7 @@ Item {
                     smooth: false
                     antialiasing: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 21
                     lineHeight: 1.1
@@ -97,7 +97,7 @@ Item {
                         smooth: false
                         antialiasing: false
                         font.letterSpacing: 3
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 18
                         color: "#ffffff"
@@ -118,7 +118,7 @@ Item {
                         smooth: false
                         antialiasing: false
                         font.letterSpacing: 3
-                        font.family: "Antenna"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 18
                         color: "#ffffff"
@@ -133,7 +133,7 @@ Item {
                     smooth: false
                     antialiasing: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pixelSize: 18
                     color: "#ffffff"
@@ -215,7 +215,7 @@ Item {
                     smooth: false
                     antialiasing: false
                     font.letterSpacing: 3
-                    font.family: "Antenna"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 21
                     lineHeight: 1.1
@@ -252,7 +252,7 @@ Item {
                             antialiasing: false
                             font.wordSpacing: 2
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.pixelSize: 18
                             visible: false
@@ -265,7 +265,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -279,7 +279,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -293,7 +293,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -307,7 +307,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -320,7 +320,7 @@ Item {
                             antialiasing: false
                             smooth: false
                             font.wordSpacing: 2
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -342,7 +342,7 @@ Item {
                             font.letterSpacing: 3
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.pixelSize: 18
                             visible: false
@@ -354,7 +354,7 @@ Item {
                             text: qsTr("99.99%")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -367,7 +367,7 @@ Item {
                             text: layer_height_mm
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -380,7 +380,7 @@ Item {
                             text: qsTr("2")
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -393,7 +393,7 @@ Item {
                             text: qsTr("%1 %2").arg(model_mass).arg(print_model_material)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18
@@ -406,7 +406,7 @@ Item {
                             text: qsTr("%1 %2").arg(support_mass).arg(print_support_material)
                             antialiasing: false
                             smooth: false
-                            font.family: "Antenna"
+                            font.family: defaultFont.name
                             font.weight: Font.Bold
                             font.letterSpacing: 3
                             font.pixelSize: 18

--- a/src/qml/TimeSelectorForm.qml
+++ b/src/qml/TimeSelectorForm.qml
@@ -81,7 +81,7 @@ Item {
             verticalAlignment: Text.AlignVCenter
             font.pixelSize: Tumbler.tumbler.count > 2 ? 175 : 60
             font.weight: Font.Light
-            font.family: "Antennae"
+            font.family: defaultFont.name
             color: "#ffffff"
         }
     }
@@ -111,7 +111,7 @@ Item {
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
             anchors.verticalCenter: parent.verticalCenter
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 135
         }
 

--- a/src/qml/TimeZoneButtonForm.qml
+++ b/src/qml/TimeZoneButtonForm.qml
@@ -55,7 +55,7 @@ Button {
         anchors.left: parent.left
         anchors.leftMargin: 25
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14
@@ -72,7 +72,7 @@ Button {
         anchors.left: parent.left
         anchors.leftMargin: 120
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 2
         font.weight: Font.Bold
         font.pointSize: 14
@@ -88,7 +88,7 @@ Button {
         anchors.right: parent.right
         anchors.rightMargin: 25
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14

--- a/src/qml/TimeZoneLocationSeparatorForm.qml
+++ b/src/qml/TimeZoneLocationSeparatorForm.qml
@@ -13,7 +13,7 @@ Item {
         anchors.leftMargin: 25
         anchors.verticalCenter: parent.verticalCenter
         anchors.verticalCenterOffset: -5
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14

--- a/src/qml/TitleText.qml
+++ b/src/qml/TitleText.qml
@@ -4,7 +4,7 @@ Text {
     font.letterSpacing: 3
     wrapMode: Text.WordWrap
     color: "#e6e6e6"
-    font.family: "Antennae"
+    font.family: defaultFont.name
     font.pixelSize: 20
     font.weight: Font.Bold
     lineHeight: 1.3

--- a/src/qml/ToolheadCalibrationForm.qml
+++ b/src/qml/ToolheadCalibrationForm.qml
@@ -94,7 +94,7 @@ Item {
             anchors.left: parent.left
             anchors.leftMargin: 0
             color: "#e6e6e6"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 26
             font.weight: Font.Bold
             lineHeight: 1.2
@@ -110,7 +110,7 @@ Item {
             anchors.left: parent.left
             anchors.leftMargin: 0
             color: "#e6e6e6"
-            font.family: "Antennae"
+            font.family: defaultFont.name
             font.pixelSize: 18
             font.weight: Font.Light
             text: qsTr("Use this process anytime an extruder (new or used) is attached to the printer.")
@@ -156,7 +156,7 @@ Item {
             Text {
                 id: extruder_A_current_temperature_text
                 text: bot.extruderACurrentTemp + "C"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -175,7 +175,7 @@ Item {
                 text: (bot.process.stateType == ProcessStateType.CoolingNozzle) ?
                            "50C" :
                            (bot.extruderATargetTemp + "C")
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -190,7 +190,7 @@ Item {
             Text {
                 id: extruder_B_current_temperature_text
                 text: bot.extruderBCurrentTemp + "C"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -209,7 +209,7 @@ Item {
                 text: (bot.process.stateType == ProcessStateType.CoolingNozzle) ?
                           "50C" :
                           (bot.extruderBTargetTemp + "C")
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 color: "#ffffff"
                 font.letterSpacing: 3
                 font.weight: Font.Light
@@ -845,7 +845,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -883,7 +883,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -920,7 +920,7 @@ Item {
                     text: qsTr("STOP CALIBRATION?")
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }
@@ -934,7 +934,7 @@ Item {
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.weight: Font.Light
                     wrapMode: Text.WordWrap
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.pixelSize: 18
                     lineHeight: 1.3
                 }

--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -106,7 +106,7 @@ Item {
             antialiasing: false
             smooth: false
             verticalAlignment: Text.AlignVCenter
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 3
             font.weight: Font.Light
             font.pixelSize: 22
@@ -304,7 +304,7 @@ Item {
             antialiasing: false
             smooth: false
             verticalAlignment: Text.AlignVCenter
-            font.family: "Antenna"
+            font.family: defaultFont.name
             font.letterSpacing: 3
             font.weight: Font.Light
             font.pixelSize: 22

--- a/src/qml/WiFiButtonForm.qml
+++ b/src/qml/WiFiButtonForm.qml
@@ -49,7 +49,7 @@ Button {
         anchors.left: parent.left
         anchors.leftMargin: 75
         anchors.verticalCenter: parent.verticalCenter
-        font.family: "Antenna"
+        font.family: defaultFont.name
         font.letterSpacing: 3
         font.weight: Font.Bold
         font.pointSize: 14

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -107,7 +107,7 @@ Item {
             // 'Not Connected' or 'NoWifiFound' states.
             Text {
                 color: "#ffffff"
-                font.family: "Antennae"
+                font.family: defaultFont.name
                 font.weight: Font.Light
                 text: {
                     if(!bot.net.wifiEnabled) {
@@ -255,7 +255,7 @@ Item {
                     anchors.left: passwordField.left
                     anchors.bottom: passwordField.top
                     anchors.bottomMargin: 10
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                 }
 
@@ -276,7 +276,7 @@ Item {
                             color: "#f7f7f7"
                         }
                     color: "#000000"
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Light
                     font.pointSize: (showPassword.checked ||
                                     text == "") ? 14 : 24
@@ -345,7 +345,7 @@ Item {
                         color: "#ffffff"
                         text: qsTr("Show Password")
                         font.letterSpacing: 2
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.weight: Font.Light
                         font.pixelSize: 18
                     }
@@ -476,7 +476,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -524,7 +524,7 @@ Item {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -588,7 +588,7 @@ Item {
                         Layout.fillWidth: false
                         font.letterSpacing: 3
                         font.weight: Font.Bold
-                        font.family: "Antennae"
+                        font.family: defaultFont.name
                         font.pixelSize: 18
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -670,7 +670,7 @@ Item {
                     font.capitalization: Font.AllUppercase
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    font.family: "Antennae"
+                    font.family: defaultFont.name
                     font.weight: Font.Bold
                     font.pixelSize: 20
                 }


### PR DESCRIPTION
The CJK fonts added are a subset of NotoSansCJK which includes the
set of most common CJK characters in the unicode range U+4E00-U+9FFF
(CJK Unified Ideographs) covering Chinese & Japanese characters and
the unicode range U+AC00-U+D7AF for 'Hangul' syllables for Korean
language characters.

Switched to using Font Loader for loading fonts rather than specifying
the font everywhere. Qt seems to be smart in using all available fonts
in /usr/lib/font directory to render all characters even if the current
font doesn't support them. However the font loader might be needed when
we add fonts to qt resource system to make them part of the UI program
when we have to manually load a font depending on the selected language.
Either way it is better to specify the font name at just one place.