### PR TITLE
Add error message suggesting to use a differet extruder

### DIFF
--- a/src/qml/ExtruderForm.qml
+++ b/src/qml/ExtruderForm.qml
@@ -118,7 +118,7 @@ Item {
                         case 1:
                             switch(bot.extruderAType) {
                             case ExtruderType.MK14:
-                                "1"
+                                "1A"
                                 break;
                             case ExtruderType.MK14_HOT:
                                 "1XA"
@@ -128,7 +128,7 @@ Item {
                         case 2:
                             switch(bot.extruderBType) {
                             case ExtruderType.MK14:
-                                "2"
+                                "2A"
                                 break;
                             case ExtruderType.MK14_HOT:
                                 "2XA"

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -5,6 +5,7 @@ import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
 import FreStepEnum 1.0
 import ExtruderTypeEnum 1.0
+import MachineTypeEnum 1.0
 
 Item {
     id: materialPage
@@ -676,11 +677,21 @@ Item {
                 Text {
                     id: title_text_mat_warning_popup
                     color: "#cbcbcb"
-                    text: isMaterialMismatch ?
-                              (loadUnloadFilamentProcess.currentActiveTool == 1 ?
-                                  qsTr("MODEL MATERIAL REQUIRED") :
-                                  qsTr("SUPPORT MATERIAL REQUIRED")) :
-                                  qsTr("UNKNOWN MATERIAL WARNING")
+                    text: {
+                        if(isMaterialMismatch) {
+                            if (loadUnloadFilamentProcess.currentActiveTool == 1) {
+                                if (bot.machineType == MachineType.Lava && materialPage.bay1.filamentMaterialName == "ABS") {
+                                    qsTr("UNSUPPORTED MATERIAL DETECTED")
+                                } else {
+                                    qsTr("MODEL MATERIAL REQUIRED")
+                                }
+                            } else if (loadUnloadFilamentProcess.currentActiveTool == 2) {
+                                qsTr("SUPPORT MATERIAL REQUIRED")
+                            }
+                        } else {
+                            qsTr("UNKNOWN MATERIAL WARNING")
+                        }
+                    }
                     font.letterSpacing: 3
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.family: defaultFont.name
@@ -696,19 +707,27 @@ Item {
                             if(loadUnloadFilamentProcess.currentActiveTool == 1) {
                                 switch (bot.extruderAType) {
                                 case ExtruderType.MK14:
-                                    qsTr("Only model materials PLA, Tough and PETG are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    // This is a special case when V1 extruder is being used on
+                                    // a V2 printer and the user tries to load a V2 hot extruder
+                                    // specific material. This warning can be made generic for
+                                    // all such materials.
+                                    if (bot.machineType == MachineType.Lava && materialPage.bay1.filamentMaterialName == "ABS") {
+                                        qsTr("Only PLA, Tough and PETG model material are compatible with a Model 1A Extruder. Insert a Model 1XA Extruder to print ABS")
+                                    } else {
+                                        qsTr("Only PLA, Tough and PETG model material are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    }
                                     break;
                                 case ExtruderType.MK14_HOT:
-                                    qsTr("Only model material ABS is compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    qsTr("Only ABS model material is compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
                                     break;
                                 }
                             } else if(loadUnloadFilamentProcess.currentActiveTool == 2) {
                                 switch (bot.extruderBType) {
                                 case ExtruderType.MK14:
-                                    qsTr("Only support material PVA is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
+                                    qsTr("Only PVA support material is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
                                     break;
                                 case ExtruderType.MK14_HOT:
-                                    qsTr("Only support material SR-30 is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
+                                    qsTr("Only SR-30 support material is compatible in material bay 2. Insert MakerBot support material in material bay 2 to continue.")
                                     break;
                                 }
                             }

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -1776,11 +1776,11 @@ ApplicationWindow {
                             if (bot.machineType == MachineType.Fire) {
                                 // V1 printers support only mk14 extruders.
                                 if (wrongExtruderPopup.modelExtWrong) {
-                                    qsTr("Please insert a Model 1 Performance Extruder "+
+                                    qsTr("Please insert a Model 1A Performance Extruder "+
                                          "into slot 1\nto continue attaching the "+
                                          "extruders.")
                                 } else if (wrongExtruderPopup.supportExtWrong) {
-                                    qsTr("Please insert a Support 2 Performance Extruder "+
+                                    qsTr("Please insert a Support 2A Performance Extruder "+
                                          "into slot 2\nto continue attaching the "+
                                          "extruders. Currently only model\nand support "+
                                          "printing is supported.")
@@ -1790,11 +1790,11 @@ ApplicationWindow {
                             } else if (bot.machineType == MachineType.Lava) {
                                 // Hot bot (V2) supports both mk14 and mk14_hot extruders.
                                 if (wrongExtruderPopup.modelExtWrong) {
-                                    qsTr("Please insert a Model 1 or Model 1XA Performance\n" +
+                                    qsTr("Please insert a Model 1A or Model 1XA Performance\n" +
                                          "Extruder into slot 1 to continue attaching the " +
                                          "extruders.")
                                 } else if (wrongExtruderPopup.supportExtWrong) {
-                                    qsTr("Please insert a Support 2 or Support 2XA Performance\n" +
+                                    qsTr("Please insert a Support 2A or Support 2XA Performance\n" +
                                          "Extruder into slot 2 to continue attaching the extruders.\n" +
                                          "Currently only model and support printing is supported. ")
                                 } else {


### PR DESCRIPTION
While loading ABS on V2 printers wiht V1 extruders installed
tell the user to switch to a V2 extruder to use this material.
This warning can be made generic for all such possible
materials, but right now there's one material ABS which
throws this error as per the spec.
Also renamed 1 & 2 extruders to 1A & 2A respectively.

It was also decided while discussing the ticket to not bother
about extruder combination mismatch errors (v1 model extruder
with v2 support extruder) considering single extruder printing
support rollout soon which doesnt care about the second extruder
at all apart from it's mass.

BW-4943
https://makerbot.atlassian.net/browse/BW-4943