### PR TITLE
Use more reliable way to auto size buttons

### DIFF
--- a/src/qml/RoundedButtonForm.qml
+++ b/src/qml/RoundedButtonForm.qml
@@ -18,7 +18,7 @@ Rectangle {
     property bool forceButtonWidth: false
 
     id: button_rectangle
-    width: forceButtonWidth ? buttonWidth : (button_text.width + 30)
+    width: forceButtonWidth ? buttonWidth : (button_text.contentWidth + 35)
     height: 40
     color: is_button_transparent ? "#00000000" : button_not_pressed_color
     radius: 8


### PR DESCRIPTION
This fixes buttons to not be abnormally wide when their label
has multiple lines of text -- confirm extrusion button. Seems
to work fine everywhere else too.