### PR TITLE
Add single extruder print support

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -2823,13 +2823,18 @@ ApplicationWindow {
                                 qsTr("Close the build chamber door to start the print.")
                             }
                             else if(printPage.startPrintNoFilament) {
-                                qsTr("There is no material detected in at least one of the extruders." +
-                                     " Please load material to start a print.")
+                                if (printPage.model_extruder_used && printPage.support_extruder_used) {
+                                    qsTr("There is no material detected in at least one of the extruders." +
+                                         " Please load material to start a print.")
+                                } else if (printPage.model_extruder_used && !printPage.support_extruder_used) {
+                                    qsTr("There is no material detected in the model extruder." +
+                                         " Please load material to start a print.")
+                                }
                             }
                             else if(printPage.startPrintMaterialMismatch) {
                                 qsTr("This print requires <b>%1</b> in <b>Model Extruder 1</b>").arg(
                                             printPage.print_model_material.toUpperCase()) +
-                                        (printPage.print_support_material == "" ?
+                                        (!printPage.support_extruder_used ?
                                             "." :
                                             (" and <b>%2</b> in <b>Support Extruder 2</b>.").arg(
                                                 printPage.print_support_material.toUpperCase())) +
@@ -2849,7 +2854,7 @@ ApplicationWindow {
                             else if(printPage.startPrintWithUnknownMaterials) {
                                 qsTr("Be sure <b>%1</b> is in <b>Model Extruder 1</b>").arg(
                                      printPage.print_model_material.toUpperCase()) +
-                                 ((printPage.print_support_material != "") ?
+                                 (printPage.support_extruder_used ?
                                             qsTr(" and <b>%1</b> is in <b>Support Extruder 2</b>.").arg(
                                                  printPage.print_support_material.toUpperCase()) :
                                             qsTr(".")) +

--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -29,7 +29,7 @@ PrintPageForm {
 
         var modelMaterialOK = false
         // Single extruder prints
-        if(print_support_material == "" && print_model_material != "") {
+        if(model_extruder_used && !support_extruder_used) {
             if(materialPage.bay1.filamentMaterialName.toLowerCase() !=
                     print_model_material) {
                 startPrintMaterialMismatch = true
@@ -42,7 +42,7 @@ PrintPageForm {
         }
 
         // Dual extruder prints
-        if(print_support_material != "" && print_model_material != "") {
+        if(support_extruder_used && model_extruder_used) {
             if(print_model_material == "unknown" || materialPage.bay1.isUnknownMaterial) {
                 if(print_model_material == "unknown" && materialPage.bay1.isMaterialValid) {
                     startPrintUnknownSliceGenuineMaterial = true
@@ -99,11 +99,17 @@ PrintPageForm {
     }
 
     function startPrintFilamentCheck() {
-        if(!bot.extruderAFilamentPresent || !bot.extruderBFilamentPresent) {
+        if (model_extruder_used && support_extruder_used &&
+            (!bot.extruderAFilamentPresent || !bot.extruderBFilamentPresent)) {
             startPrintNoFilament = true
-            if(bot.process.stateType == ProcessStateType.Failed) {
-                bot.done("acknowledge_failure")
-            }
+        } else if (model_extruder_used && !support_extruder_used &&
+                   !bot.extruderAFilamentPresent) {
+            startPrintNoFilament = true
+        }
+        if(bot.process.stateType == ProcessStateType.Failed) {
+            bot.done("acknowledge_failure")
+        }
+        if (startPrintNoFilament) {
             return false
         }
         return true

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -15,6 +15,8 @@ Item {
     property string uses_support_
     property string uses_raft_
     property string print_time_
+    property bool model_extruder_used_
+    property bool support_extruder_used_
     property string print_model_material_
     property string print_support_material_
     property string printerName: bot.name
@@ -219,8 +221,10 @@ Item {
                             } else if(bot.process.stepStr == "transfer") {
                                 bot.process.printPercentage + "%"
                             } else if(bot.extruderATargetTemp > 0) {
-                                (qsTr("%1 C").arg(bot.extruderACurrentTemp) + " | " + qsTr("%1 C\n").arg(bot.extruderATargetTemp) +
-                                 qsTr("%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp))
+                                (qsTr("%1 C").arg(bot.extruderACurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderATargetTemp) +
+                                 support_extruder_used_ ?
+                                     qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp) :
+                                     "\n")
                             } else {
                                 (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
                             }
@@ -429,6 +433,7 @@ Item {
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
+                            visible: support_extruder_used_
                         }
                     }
 
@@ -502,6 +507,7 @@ Item {
                             font.letterSpacing: 3
                             font.pixelSize: 18
                             font.capitalization: Font.AllUppercase
+                            visible: support_extruder_used_
                         }
                     }
                 }

--- a/src/qml/StartPrintPageForm.qml
+++ b/src/qml/StartPrintPageForm.qml
@@ -155,7 +155,7 @@ Item {
                     anchors.topMargin: 12
                     filamentBayID: 2
                     materialRequired: supportMaterialRequired
-                    visible: print_support_material != ""
+                    visible: support_extruder_used
                 }
 
                 RoundedButton {
@@ -349,8 +349,8 @@ Item {
                             font.weight: Font.Light
                             font.letterSpacing: 3
                             font.pixelSize: 18
+                            visible: support_extruder_used
                         }
-
                     }
 
                     ColumnLayout {
@@ -436,6 +436,7 @@ Item {
                             font.letterSpacing: 3
                             font.pixelSize: 18
                             font.capitalization: Font.AllUppercase
+                            visible: support_extruder_used
                         }
                     }
                 }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -255,9 +255,9 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
     MakerbotFileMetaReader file_meta_reader(kFileInfo);
     if(file_meta_reader.loadMetadata()) {
         auto &meta_data = file_meta_reader.meta_data_;
-        QString material_name_a = QString::fromStdString(meta_data->material[1]);
+        QString material_name_a = QString::fromStdString(meta_data->material[0]);
         updateMaterialNames(material_name_a);
-        QString material_name_b = QString::fromStdString(meta_data->material[0]);
+        QString material_name_b = QString::fromStdString(meta_data->material[1]);
         updateMaterialNames(material_name_b);
         return
             // e.g. "/tmp/archive.tar.gz"
@@ -270,10 +270,12 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
                                                 // like baseName()
                   kFileInfo.lastRead(),
                   kFileInfo.isDir(),
-                  meta_data->extrusion_mass_g[1],
+                  (meta_data->extrusion_distance_mm[0] > 0.0),
+                  (meta_data->extrusion_distance_mm[1] > 0.0),
                   meta_data->extrusion_mass_g[0],
-                  meta_data->extruder_temperature[1],
+                  meta_data->extrusion_mass_g[1],
                   meta_data->extruder_temperature[0],
+                  meta_data->extruder_temperature[1],
                   meta_data->chamber_temperature,
                   meta_data->shells,
                   meta_data->layer_height,

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -52,6 +52,8 @@ class PrintFileInfo : public QObject {
 
   // see morepork-libtinything/include/tinything/TinyThingReader.hh for a
   // complete list of the available meta items.
+  Q_PROPERTY(bool extruderUsedA READ extruderUsedA NOTIFY fileInfoChanged)
+  Q_PROPERTY(float extruderUsedB READ extruderUsedB NOTIFY fileInfoChanged)
   Q_PROPERTY(float extrusionMassGramsA READ extrusionMassGramsA NOTIFY fileInfoChanged)
   Q_PROPERTY(float extrusionMassGramsB READ extrusionMassGramsB NOTIFY fileInfoChanged)
   Q_PROPERTY(int extruderTempCelciusA READ extruderTempCelciusA NOTIFY fileInfoChanged)
@@ -70,6 +72,7 @@ class PrintFileInfo : public QObject {
   QString file_name_, file_path_, file_base_name_;
   QDateTime file_last_read_;
   bool is_dir_;
+  bool extruder_used_a_, extruder_used_b_;
   float extrusion_mass_grams_a_, extrusion_mass_grams_b_;
   int extruder_temp_celcius_a_, extruder_temp_celcius_b_,
       chamber_temp_celcius_, num_shells_;
@@ -92,6 +95,8 @@ class PrintFileInfo : public QObject {
                   const QString &file_base_name,
                   const QDateTime &file_last_read,
                   const bool &is_dir,
+                  const bool extruder_used_a = false,
+                  const bool extruder_used_b = false,
                   const float extrusion_mass_grams_a = 0.0f,
                   const float extrusion_mass_grams_b = 0.0f,
                   const int extruder_temp_celcius_a = 0,
@@ -113,6 +118,8 @@ class PrintFileInfo : public QObject {
                   file_base_name_(file_base_name),
                   file_last_read_(file_last_read),
                   is_dir_(is_dir),
+                  extruder_used_a_(extruder_used_a),
+                  extruder_used_b_(extruder_used_b),
                   extrusion_mass_grams_a_(extrusion_mass_grams_a),
                   extrusion_mass_grams_b_(extrusion_mass_grams_b),
                   extruder_temp_celcius_a_(extruder_temp_celcius_a),
@@ -134,6 +141,8 @@ class PrintFileInfo : public QObject {
         file_base_name_ = rvalue.file_base_name_;
         file_last_read_ = rvalue.file_last_read_;
         is_dir_ = rvalue.is_dir_;
+        extruder_used_a_ = rvalue.extruder_used_a_;
+        extruder_used_b_ = rvalue.extruder_used_b_;
         extrusion_mass_grams_a_ = rvalue.extrusion_mass_grams_a_;
         extrusion_mass_grams_b_ = rvalue.extrusion_mass_grams_b_;
         extruder_temp_celcius_a_ = rvalue.extruder_temp_celcius_a_;
@@ -157,6 +166,8 @@ class PrintFileInfo : public QObject {
                 rvalue.file_base_name_,
                 rvalue.file_last_read_,
                 rvalue.is_dir_,
+                rvalue.extruder_used_a_,
+                rvalue.extruder_used_b_,
                 rvalue.extrusion_mass_grams_a_,
                 rvalue.extrusion_mass_grams_b_,
                 rvalue.extruder_temp_celcius_a_,
@@ -188,6 +199,12 @@ class PrintFileInfo : public QObject {
     }
     bool isDir() const {
         return is_dir_;
+    }
+    bool extruderUsedA() const {
+        return extruder_used_a_;
+    }
+    bool extruderUsedB() const {
+        return extruder_used_b_;
     }
     float extrusionMassGramsA() const {
         return extrusion_mass_grams_a_;


### PR DESCRIPTION
The UI will skip all checks for unused extruder and will hide
unused extruder/material stats when running a single extruder
print.

Also cleaned up extruder 0,1 - A,B mapping between the UI and
UI side libtinything interface. A is model and B is support
throughout the UI now.

BW-4919
https://makerbot.atlassian.net/browse/BW-4919