### PR TITLE
Add extruder combination mismatch error

### DIFF
--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -24,6 +24,7 @@ class BotModel : public BaseModel {
 
     // MOREPORK_QML_ENUM
     enum ExtruderType {
+        NONE,
         MK14,
         MK14_HOT
     };
@@ -114,8 +115,8 @@ class BotModel : public BaseModel {
     MODEL_PROP(bool, isInstallUnsignedFwRequestPending, false)
     // TODO(praveen): Would be good to move these extruder
     //                properties to it's own sub model.
-    MODEL_PROP(ExtruderType, extruderAType, MK14)
-    MODEL_PROP(ExtruderType, extruderBType, MK14)
+    MODEL_PROP(ExtruderType, extruderAType, NONE)
+    MODEL_PROP(ExtruderType, extruderBType, NONE)
     MODEL_PROP(bool, updatingExtruderFirmware, false)
     MODEL_PROP(int, extruderFirmwareUpdateProgressA, 0)
     MODEL_PROP(int, extruderFirmwareUpdateProgressB, 0)

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -270,6 +270,19 @@ ApplicationWindow {
         }
     }
 
+    // Machine/Kaiten doesn't evaluate extruder combos, they just
+    // check if an extruder is valid on the installed slot for that
+    // machine. So the 'tool_type_correct' flag cannot be used to
+    // show the extruder combo warning.
+    //
+    // This is required now to cover a specific case described
+    // in BW-4975 (https://makerbot.atlassian.net/browse/BW-4975)
+    // or atleast until single extruder support is launched to public?
+    property bool extruderComboMismatch: {
+        (bot.extruderAType == ExtruderType.MK14 && bot.extruderBType == ExtruderType.MK14_HOT) ||
+        (bot.extruderAType == ExtruderType.MK14_HOT && bot.extruderBType == ExtruderType.MK14)
+    }
+
     Item {
         id: rootItem
         smooth: false
@@ -1765,7 +1778,7 @@ ApplicationWindow {
             property bool supportExtWrong: extruderBPresent &&
                                          !extruderBToolTypeCorrect
             id: wrongExtruderPopup
-            visible: modelExtWrong || supportExtWrong
+            visible: modelExtWrong || supportExtWrong || extruderComboMismatch
             disableUserClose: true
             popup_contents.contentItem: Item {
                 anchors.fill: parent
@@ -1781,7 +1794,12 @@ ApplicationWindow {
                     }
                     BodyText{
                         text: {
-                            if (bot.machineType == MachineType.Fire) {
+                            if (extruderComboMismatch) {
+                                qsTr("A Model 1XA Extruder can only be used with a " +
+                                     "Support 2XA Extruder.\nA Model 1A Extruder can " +
+                                     "only be used with a Support 2A Extruder.")
+                            }
+                            else if (bot.machineType == MachineType.Fire) {
                                 // V1 printers support only mk14 extruders.
                                 if (wrongExtruderPopup.modelExtWrong) {
                                     qsTr("Please insert a Model 1A Performance Extruder "+


### PR DESCRIPTION
This is a UI side feature to prevent users from installing a
support extruder in FRE and then only get blocked at test print
after leveling, calibrating & loading material because it doesn't
correspond to the model extruder (no way to slice for extruder
combo) but is still individually compatible with the support slot
for the machine.

This needs to evolve in some way when single extruder printing
rolls out.

BW-4975
https://makerbot.atlassian.net/browse/BW-4975