### PR TITLE
Tweak back button in wifi page for correct behavior while in FRE

### DIFF
--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -247,7 +247,6 @@ Item {
                 id: wifiPage
 
             }
-
         }
 
         //settingsSwipeView.index = 4

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -97,8 +97,23 @@ Item {
             // backSwiper and backSwipeIndex are used by backClicked
             property var backSwiper: settingsSwipeView
             property int backSwipeIndex: 0
+            property bool hasAltBack: true
             smooth: false
             visible: true
+
+            function altBack() {
+                if(!inFreStep) {
+                    settingsSwipeView.swipeToItem(0)
+                }
+                else {
+                    skipFreStepPopup.open()
+                }
+            }
+
+            function skipFreStepAction() {
+                settingsSwipeView.swipeToItem(0)
+                mainSwipeView.swipeToItem(0)
+            }
 
             // When the bot is not connected to wifi and the user
             // performs a wifi scan. In this case a deep scan happens


### PR DESCRIPTION
Have explicit back button action defined for first page of wifi
screen. The first page back button action is defined in the
parent level item in the settings page that holds the wifi page.
It is also needed here for cases when other pages in the wifi
page are swiped to, which makes the current item control to be
transferred to the wifi page item and then going back from the
first page has incorrect behavior.

This is one of the quirks of having nested SwipeViews with the
current back button logic.

BW-4977
https://makerbot.atlassian.net/browse/BW-4977