### PR TITLE
Change generic model name string

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -474,7 +474,7 @@ void MoreporkStorage::updateMaterialNames(QString &name) {
         name = "petg";
     } else if(name == "sr30") {
         name = "sr-30";
-    } else if(name == "generic_model") {
+    } else if(name == "generic-model") {
         name = "unknown";
     }
 }


### PR DESCRIPTION
Use 'generic-model' instead of 'generic_model' for unknown material.