### PR TITLE
Block load/unload during print when not paused

### DIFF
--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -65,7 +65,7 @@ MaterialPageForm {
             // Always allow loading while idle (material mismatch blocking occurs
             // after starting the process)
             return true
-        } else if(!printPage.isPrintProcess || !bot.process.stateType == ProcessStateType.Paused) {
+        } else if(!printPage.isPrintProcess || bot.process.stateType != ProcessStateType.Paused) {
             // During a paused print is the only non-idle state that allows filament change
             return false
         } else if(isExtruderFilamentPresent(extruderID)) {


### PR DESCRIPTION
BW-4993
http://makerbot.atlassian.net/browse/BW-4993

This fixes an order of operations bug where we intended to block loading and unloading during a print process, but actually allow a user to select this in any print step.  (As the rest of the UI is not coded with the intention of allowing this, we actually get into a weird UI state when this happens instead of actually correctly requesting this action from kaiten.)