### PR TITLE
False Negative on Wifi

### DIFF
--- a/src/model_impl/kaiten_net_model.cpp
+++ b/src/model_impl/kaiten_net_model.cpp
@@ -27,9 +27,6 @@ void KaitenNetModel::netUpdate(const Json::Value &state) {
         const QString kIfaceStr = kIface.asString().c_str();
         if (kIfaceStr == "wifi")
             wifiStateSet(WifiState::Connected);
-        else if(kIfaceStr == "ethernet" ||
-                kIfaceStr == "offline")
-            wifiStateSet(WifiState::NotConnected);
     }
 
     QString eth_mac_addr, wlan_mac_addr;
@@ -74,7 +71,6 @@ void KaitenNetModel::wifiUpdate(const Json::Value &result) {
             wifiStateSet(WifiState::NoWifiFound);
             WiFiListReset();
         } else {
-            wifiStateSet(WifiState::NotConnected);
             WiFiListSet(wifi_list);
         }
     }

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -51,7 +51,9 @@ Item {
             }
         }
         else {
-            bot.net.setWifiState(WifiState.NotConnected)
+            if (bot.net.wifiState != WifiState.Connecting) {
+                bot.net.setWifiState(WifiState.NotConnected)
+            }
         }
     }
 
@@ -633,7 +635,7 @@ Item {
                             else if(bot.net.wifiError == WifiError.InvalidPassword) {
                                 wifiPopup.close()
                             }
-                            else if(bot.net.wifiState == WifiState.NotConnected) {
+                            if(wifiPopup.opened) {
                                 wifiPopup.close()
                             }
                         }
@@ -662,10 +664,11 @@ Item {
                         if(isForgetEnabled) {
                             qsTr("FORGET %1?").arg(selectedWifiName)
                         }
-                        else if(bot.net.wifiState == WifiState.Connecting ||
-                                bot.net.wifiState == WifiState.Connected ||
-                                bot.net.wifiState == WifiState.Connected) {
+                        else if(bot.net.wifiState == WifiState.Connecting) {
                             qsTr("CONNECTING TO %1").arg(selectedWifiName)
+                        }
+                        else if(bot.net.wifiState == WifiState.Connected) {
+                            qsTr("CONNECTED")
                         }
                         else if(bot.net.wifiState == WifiState.Disconnecting) {
                             qsTr("DISCONNECT FROM %1?").arg(selectedWifiName)
@@ -674,11 +677,8 @@ Item {
                             if(bot.net.wifiError == WifiError.InvalidPassword) {
                                 qsTr("INVALID PASSWORD")
                             }
-                            else if(bot.net.wifiError == WifiError.ConnectFailed) {
+                            else if (bot.net.wifiError != WifiError.NoError) {
                                 qsTr("FAILED TO CONNECT TO %1").arg(selectedWifiName)
-                            }
-                            else if(bot.net.wifiState == WifiState.NotConnected) {
-                                qsTr("CONNECTION FAILED")
                             }
                         }
                     }


### PR DESCRIPTION
- Do not force a NotConnected state anywhere because the wifi could be connecting to a new network.
- Split up Connecting message and Connected message in wifi popup.
- Display Failed to Connect in wifi popup if there was a Wifi Error and not if the state is Not Connected.

BW-5014
http://makerbot.atlassian.net/browse/BW-5014