### PR TITLE
Modular Extruder Loading Temperatures

### DIFF
--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -111,7 +111,11 @@ MaterialPageForm {
     bay1 {
         loadButton {
             button_mouseArea.onClicked: {
-                if(experimentalExtruderInstalled) {
+                // Only if an experimental extruder is installed and there is no recognized
+                // material spool in the bay, do we want the user to choose a load temperature.
+                // Otherwise, Kaiten should handle using the proper temperature for the material
+                // loaded in the bay.
+                if(experimentalExtruderInstalled && bay1.filamentMaterialName == "UNKNOWN") {
                     isLoadFilament = true
                     materialSwipeView.swipeToItem(1)
                     return;
@@ -137,7 +141,11 @@ MaterialPageForm {
 
         unloadButton {
             button_mouseArea.onClicked: {
-                if(experimentalExtruderInstalled) {
+                // Only if an experimental extruder is installed and there is no recognized
+                // material spool in the bay, do we want the user to choose an unload temperature.
+                // Otherwise, Kaiten should handle using the proper temperature for the material
+                // loaded in the bay.
+                if(experimentalExtruderInstalled && bay1.filamentMaterialName == "UNKNOWN") {
                     isLoadFilament = false
                     materialSwipeView.swipeToItem(1)
                     return;


### PR DESCRIPTION
- User will only get to choose the load/unload temperature for experimental
  extruder when there is no spool in the bay. Otherwise, the load/unload
  temps loaded by Kaiten will be used.
- Currently, Kaiten loads the default load/unload temperatures for that extruder.
  However, a separate ticket has been made to fix loading the proper temps
  depending on the material spool in the filament bay.

BW-5032
http://makerbot.atlassian.net/browse/BW-5032