### PR TITLE
Skip material check for mid-print loading

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -84,12 +84,24 @@ ErrorScreenForm {
 
                 // Disable load button until the printer isn't completely
                 // paused (auto-unloading) or when there is no correct
-                // material spool on the bay for the paused print.
-                (bot.process.stateType != ProcessStateType.Paused ||
-                (bot.process.stateType == ProcessStateType.Paused &&
-                  (bot.process.filamentBayAOOF || bot.process.extruderAOOF ?
-                      printPage.print_model_material != materialPage.bay1.filamentMaterialName.toLowerCase() :
-                      printPage.print_support_material != materialPage.bay2.filamentMaterialName.toLowerCase())))
+                // material spool on the bay for the paused print. Skip
+                // the material check when using experimental extruder.
+                if(bot.process.stateType != ProcessStateType.Paused) {
+                   true
+                } else if(bot.process.stateType == ProcessStateType.Paused) {
+                    if(materialPage.isUsingExpExtruder(bot.process.errorSource + 1)) {
+                        // Allow loading if the offending extruder is an experimental
+                        // extruder
+                        false
+                    } else {
+                        // For normal extruders only allow loading if the bay material
+                        // matches the print material which is the same logic used in the
+                        // material page.
+                        isExtruderAError() ?
+                            printPage.print_model_material != materialPage.bay1.filamentMaterialName.toLowerCase() :
+                            printPage.print_support_material != materialPage.bay2.filamentMaterialName.toLowerCase()
+                    }
+                }
             }
             else if (state == "calibration_failed") {
                 bot.process.type != ProcessType.None


### PR DESCRIPTION
When printing using a genuine material on the exp. extruder the printer will
pause on bay oof errors(if the spool journal has the loaded material) and the
user can load material directly from the oof error screen. However the load
button is disabled unless the user puts a matching material as the ongoing
print. This commit changes that behavior and enables that button without any
material checks when an exp. extruder is present.

Even without this change, material can be loaded from the material page mid-
print and only not directly from the error screen, but this change makes it
much less confusing for the user.