### PR TITLE
Translations were either incorrect or too wide

### DIFF
--- a/src/qml/LanguageSelectorForm.qml
+++ b/src/qml/LanguageSelectorForm.qml
@@ -34,7 +34,7 @@ Item {
 
             LanguageButton {
                 id: buttonLanguageChinese
-                languageName: "中文"
+                languageName: "中文（简体）"
                 localeCode: "zh_CN"
             }
 
@@ -64,7 +64,7 @@ Item {
 
             LanguageButton {
                 id: buttonLanguageJapanese
-                languageName: "日本人"
+                languageName: "日本語"
                 localeCode: "ja_JP"
             }
 

--- a/src/translations/translation_es_ES.ts
+++ b/src/translations/translation_es_ES.ts
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe5a43331e6f22bf106e9302ca4f09cfbe8cfc2c72b440f788817170e01370e7
-size 190619
+oid sha256:0711b7ebc854b94d79c95b228e9c477c15ddfacd9f02a039d040e6ed60443020
+size 190601


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-4933

* Chinese option now states that it is Chinese (Simplified).
* Japanese option no longer states "Japanese Person".
* In Spanish, "Opciones Avanzadas" is now narrower as "Mas Opciones",
    and should no longer overlap the "Material" icon label

The other translation "issues" are actually a problem displaying certain
characters in (so far) Chinese and Japanese. For example, the option
"Chinese (Simplified)" will only display as "Chinese Simplified", as it
is not correctly displaying the width-appropriate parentheses.

Similarly, Japanese is made up of a combination of native and borrowed
(from Chinese) characters, and it is the native characters (Kana) that are
not appearing. See also BW-4937.