### PR TITLE
Swapped out "extra" CJK chars for missing JP Kana

### DIFF
--- a/fonts/NotoSansCJK-Bold-subset.otf
+++ b/fonts/NotoSansCJK-Bold-subset.otf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0e6ac7aaa6c1ce95d614dd6b5016c1ca235da3d3eb7bf490b7bf9a2eab446bc
-size 13257312
+oid sha256:b3e0b5b1d13f533844adcf1385a3e4e8775d7cb7591b78ae16d1ce5e257c182d
+size 13208116

--- a/fonts/NotoSansCJK-Light-subset.otf
+++ b/fonts/NotoSansCJK-Light-subset.otf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74de55825b2070092c5a65bf72976f0d6294e4dc9c3fead47aaf6be3b13dbcee
-size 12630468
+oid sha256:755c87d1b0a33c8f2cb1397f74376ea8280a1564289891c066c46b8630bb1c48
+size 12591640


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-4937

In order to minimize firmware size during BW-4890, the full-sized CJK
font files (~33.212MB) were put through a process of font subsetting, which
left the Japanese translated User Interface missing large swaths of the
language (the kana). The missing-kana subsetted font resulted in a space
savings of ~7.21MB from the full font files.

Imagine someone dropping all the consonants out of english.

In this round of font-subsetting, the CJK Extensions (updates to the Unicode
Standard to add back in the "less commonly used" CJK characters) were left out,
and the missing Kana were brought back in, resulting in a space savings of
~7.7MB from the full font files.

-----

Subsetting commands used for generating this subset of NotoCJK Font files:

Including minimal kana and parens, excluding all CJK Extensions {A, B, C, D, E, F}:

U+3000-3096, punctuation, hiragana
U+30A0-30FF, katakana
U+4E00-9FFF, unified hanzi/kanji/hanja
U+AC00-D7AF, hangul syllables
U+F900-FA6A, cjk compatibility supplement
U+FF08-FF09  double-width parens

---

U+3000-3096,U+30A0-30FF,U+4E00-9FFF,U+AC00-D7AF,U+F900-FA6A,U+FF08-FF09

---

pyftsubset NotoSansCJKsc-Light.otf -unicodes=U+3000-3096,U+30A0-30FF,U+4E00-9FFF,U+AC00-D7AF,U+F900-FA6A,U+FF08-FF09 --symbol-cmap --legacy-cmap --notdef-glyph --notdef-outline --recommended-glyphs --name-IDs=’*’ --name-legacy --name-languages=’*’ --verbose

pyftsubset NotoSansCJKsc-Bold.otf --unicodes=U+3000-3096,U+30A0-30FF,U+4E00-9FFF,U+AC00-D7AF,U+F900-FA6A,U+FF08-FF09 --symbol-cmap --legacy-cmap --notdef-glyph --notdef-outline --recommended-glyphs --name-IDs=’*’ --name-legacy --name-languages=’*’ --verbose