### PR TITLE
Bw 5089 add nylon fre test print r1.6

### DIFF
--- a/test_prints/fire/test_print_nylon.makerbot
+++ b/test_prints/fire/test_print_nylon.makerbot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8d83cd373c6e353ff208377cefd7ec49debb70854eec25bed9eb3ac30dcb5b9
+size 78150

--- a/test_prints/lava/test_print_nylon.makerbot
+++ b/test_prints/lava/test_print_nylon.makerbot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c7fe3c406ec08a89409f20c9a965aac6c5125b920f24786f02c0aece5a89af
+size 78151


### PR DESCRIPTION
Added two GIT LFS files from Matt's attached files in the respective JIRA ticket:

test_prints/fire/test_print_nylon.makerbot
test_prints/lava/test_print_nylon.makerbot

Tested by calling the getTestPrint method hardcoded to "nylon" and making sure that the file path exists on the printer.
