### PR TITLE
Support for displaying chamber thermocouple and buildplane temperatures

### DIFF
--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -148,6 +148,8 @@ class BotModel : public BaseModel {
     MODEL_PROP(bool, noFilamentErrorDisabled, false)
     MODEL_PROP(int, chamberCurrentTemp, -999)
     MODEL_PROP(int, chamberTargetTemp, -999)
+    MODEL_PROP(int, buildplaneCurrentTemp, -999)
+    MODEL_PROP(int, buildplaneTargetTemp, -999)
     MODEL_PROP(int, chamberErrorCode, 0)
     MODEL_PROP(int, filamentBayATemp, -999)
     MODEL_PROP(int, filamentBayBTemp, -999)

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -1390,6 +1390,8 @@ void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {
             // Update GUI variables for chamber temps
             UPDATE_INT_PROP(chamberCurrentTemp, kChamberA["current_temperature"])
             UPDATE_INT_PROP(chamberTargetTemp, kChamberA["target_temperature"])
+            UPDATE_INT_PROP(buildplaneCurrentTemp, kChamberA["buildplane_current_temperature"])
+            UPDATE_INT_PROP(buildplaneTargetTemp, kChamberA["buildplane_target_temperature"])
             UPDATE_INT_PROP(chamberErrorCode, kChamberA["error"])
           }
         }

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -27,6 +27,7 @@ Item {
     property real layer_height_mm
     property string extruder_temp
     property string chamber_temp
+    property string buildplane_temp
     property string slicer_name
     property string readyByTime
     property int lastPrintTimeSec
@@ -177,7 +178,7 @@ Item {
         num_shells = file.numShells
         extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + "C" :
                                               file.extruderTempCelciusA + "C" + " + " + file.extruderTempCelciusB + "C"
-        chamber_temp = file.chamberTempCelcius + "C"
+        buildplane_temp = file.buildplaneTempCelcius + "C"
         slicer_name = file.slicerName
         getPrintTimes(printTimeSec)
     }
@@ -200,6 +201,7 @@ Item {
         num_shells = ""
         extruder_temp = ""
         chamber_temp = ""
+        buildplane_temp = ""
         slicer_name = ""
         startPrintWithUnknownMaterials = false
     }
@@ -620,9 +622,9 @@ Item {
                 }
 
                 InfoItem {
-                    id: printInfo_chamberTemperature
-                    labelText: qsTr("Chamber Temperature")
-                    dataText: chamber_temp
+                    id: printInfo_buildplaneTemperature
+                    labelText: qsTr("Buildplane Temperature")
+                    dataText: buildplane_temp
                 }
 
                 InfoItem {

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -234,7 +234,7 @@ Item {
                                      (qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp)) :
                                      "\n"))
                             } else {
-                                (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
+                                (qsTr("%1 C").arg(bot.buildplaneCurrentTemp) + " | " + qsTr("%1 C").arg(bot.buildplaneTargetTemp))
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -712,9 +712,9 @@ Item {
                         }
 
                         Text {
-                            id: chamber_temp_text
+                            id: buildplane_temp_text
                             color: "#ffffff"
-                            text: qsTr("%1C").arg(bot.chamberCurrentTemp)
+                            text: qsTr("%1C").arg(bot.buildplaneCurrentTemp)
                             antialiasing: false
                             smooth: false
                             font.family: defaultFont.name

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -277,6 +277,7 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
                   meta_data->extruder_temperature[0],
                   meta_data->extruder_temperature[1],
                   meta_data->chamber_temperature,
+                  meta_data->buildplane_target_temperature,
                   meta_data->shells,
                   meta_data->layer_height,
                   meta_data->infill_density,

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -59,6 +59,7 @@ class PrintFileInfo : public QObject {
   Q_PROPERTY(int extruderTempCelciusA READ extruderTempCelciusA NOTIFY fileInfoChanged)
   Q_PROPERTY(int extruderTempCelciusB READ extruderTempCelciusB NOTIFY fileInfoChanged)
   Q_PROPERTY(int chamberTempCelcius READ chamberTempCelcius NOTIFY fileInfoChanged)
+  Q_PROPERTY(int buildplaneTempCelcius READ buildplaneTempCelcius NOTIFY fileInfoChanged)
   Q_PROPERTY(int numShells READ numShells NOTIFY fileInfoChanged)
   Q_PROPERTY(float layerHeightMM READ layerHeightMM NOTIFY fileInfoChanged)
   Q_PROPERTY(float infillDensity READ infillDensity NOTIFY fileInfoChanged)
@@ -75,7 +76,7 @@ class PrintFileInfo : public QObject {
   bool extruder_used_a_, extruder_used_b_;
   float extrusion_mass_grams_a_, extrusion_mass_grams_b_;
   int extruder_temp_celcius_a_, extruder_temp_celcius_b_,
-      chamber_temp_celcius_, num_shells_;
+      chamber_temp_celcius_, buildplane_temp_celcius_, num_shells_;
   float layer_height_mm_, infill_density_, time_estimate_sec_;
   bool uses_support_, uses_raft_;
   QString material_name_a_, material_name_b_, slicer_name_;
@@ -102,6 +103,7 @@ class PrintFileInfo : public QObject {
                   const int extruder_temp_celcius_a = 0,
                   const int extruder_temp_celcius_b = 0,
                   const int chamber_temp_celcius = 0,
+                  const int buildplane_temp_celcius = 0,
                   const int num_shells = 0,
                   const float layer_height_mm = 0.0f,
                   const float infill_density = 0.0f,
@@ -125,6 +127,7 @@ class PrintFileInfo : public QObject {
                   extruder_temp_celcius_a_(extruder_temp_celcius_a),
                   extruder_temp_celcius_b_(extruder_temp_celcius_b),
                   chamber_temp_celcius_(chamber_temp_celcius),
+                  buildplane_temp_celcius_(buildplane_temp_celcius),
                   num_shells_(num_shells),
                   layer_height_mm_(layer_height_mm),
                   infill_density_(infill_density),
@@ -148,6 +151,7 @@ class PrintFileInfo : public QObject {
         extruder_temp_celcius_a_ = rvalue.extruder_temp_celcius_a_;
         extruder_temp_celcius_b_ = rvalue.extruder_temp_celcius_b_;
         chamber_temp_celcius_ = rvalue.chamber_temp_celcius_;
+        buildplane_temp_celcius_ = rvalue.buildplane_temp_celcius_;
         num_shells_ = rvalue.num_shells_;
         layer_height_mm_ = rvalue.layer_height_mm_;
         infill_density_ = rvalue.infill_density_;
@@ -173,6 +177,7 @@ class PrintFileInfo : public QObject {
                 rvalue.extruder_temp_celcius_a_,
                 rvalue.extruder_temp_celcius_b_,
                 rvalue.chamber_temp_celcius_,
+                rvalue.buildplane_temp_celcius_,
                 rvalue.num_shells_,
                 rvalue.layer_height_mm_,
                 rvalue.infill_density_,
@@ -220,6 +225,9 @@ class PrintFileInfo : public QObject {
     }
     int chamberTempCelcius() const {
         return chamber_temp_celcius_;
+    }
+    int buildplaneTempCelcius() const {
+        return buildplane_temp_celcius_;
     }
     int numShells() const {
         return num_shells_;


### PR DESCRIPTION
Soon, MBPrint will add and prioritize a new JSON member
("build_plate_temperature") in place of the now-deprecated "chamber
temperature". This is all in an effort to be less confusing about what
the chamber temperature actually is during a print.