### PR TITLE
Reset UI error flags when the error dictionary is None

### DIFF
--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -262,6 +262,9 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
         }
     } else {
         errorTypeReset();
+        CLEAR_ERROR(extruder, OOF)
+        CLEAR_ERROR(extruder, Jammed)
+        CLEAR_ERROR(filamentBay, OOF)
     }
 
     UPDATE_INT_PROP(printPercentage, proc["progress"]);


### PR DESCRIPTION
This fixes a bug that caused the UI to wrongly report that the model
extruder jammed, on all jams, after one occurence of a model extruder
jam. This happened since the model extruder jammed flag (which was set
during a previous model extruder jam) wasn't being reset when the error
went away and all subsequent jams were reported as model extruder jams.
This augments existing code that only cleared the flags when the reported
error code is 0.

BW-5153
https://makerbot.atlassian.net/browse/BW-5153