### PR TITLE
Revert outward facing build plane references

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -27,7 +27,6 @@ Item {
     property real layer_height_mm
     property string extruder_temp
     property string chamber_temp
-    property string buildplane_temp
     property string slicer_name
     property string readyByTime
     property int lastPrintTimeSec
@@ -178,7 +177,7 @@ Item {
         num_shells = file.numShells
         extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + "C" :
                                               file.extruderTempCelciusA + "C" + " + " + file.extruderTempCelciusB + "C"
-        buildplane_temp = file.buildplaneTempCelcius + "C"
+        chamber_temp = file.chamberTempCelcius + "C"
         slicer_name = file.slicerName
         getPrintTimes(printTimeSec)
     }
@@ -201,7 +200,6 @@ Item {
         num_shells = ""
         extruder_temp = ""
         chamber_temp = ""
-        buildplane_temp = ""
         slicer_name = ""
         startPrintWithUnknownMaterials = false
     }
@@ -622,9 +620,9 @@ Item {
                 }
 
                 InfoItem {
-                    id: printInfo_buildplaneTemperature
-                    labelText: qsTr("Buildplane Temperature")
-                    dataText: buildplane_temp
+                    id: printInfo_chamberTemperature
+                    labelText: qsTr("Chamber Temperature")
+                    dataText: chamber_temp
                 }
 
                 InfoItem {

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -234,7 +234,7 @@ Item {
                                      (qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp)) :
                                      "\n"))
                             } else {
-                                (qsTr("%1 C").arg(bot.buildplaneCurrentTemp) + " | " + qsTr("%1 C").arg(bot.buildplaneTargetTemp))
+                                (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -712,9 +712,9 @@ Item {
                         }
 
                         Text {
-                            id: buildplane_temp_text
+                            id: chamber_temp_text
                             color: "#ffffff"
-                            text: qsTr("%1C").arg(bot.buildplaneCurrentTemp)
+                            text: qsTr("%1C").arg(bot.chamberCurrentTemp)
                             antialiasing: false
                             smooth: false
                             font.family: defaultFont.name


### PR DESCRIPTION
We keep all of the internal tracking of the build plane temperature along
with the chamber temperature, but we don't yet want to actually release this
messaging to users yet.