### PR TITLE
Dismiss material mismatch popup when load process ends

### DIFF
--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -71,6 +71,8 @@ Item {
         }
         else {
             startLoadUnloadFromUI = false
+            materialWarningPopup.close()
+            cancelLoadUnloadPopup.close()
         }
     }
 


### PR DESCRIPTION
The mismatch popup can only be closed when the offending material spool
is removed from the filament bay when the printer is still waiting in the
load process for material acknowledgement. But the existing messaging in
the popup seems to confuse users into removing the extruder and installing
a new one in the middle of the load process, which will certainly kill the
process. Since this is a persisting popup we dismiss this and other popups
when the load process ends as the popups are really out of context at that
point.

BW-5107
https://makerbot.atlassian.net/browse/BW-5107