### PR TITLE
allow ui-settings file to disable filament nags

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -26,7 +26,7 @@ ErrorScreenForm {
     }
 
     function loadPurgeFromErrorScreen() {
-        if(isExtruderAError() && materialPage.bay1.usingExperimentalExtruder) {
+        if(isExtruderAError() && (materialPage.bay1.usingExperimentalExtruder || settings.getSkipFilamentNags)) {
             materialPage.isLoadFilament = true
             materialPage.materialSwipeView.swipeToItem(1)
             return;

--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -72,7 +72,7 @@ Item {
     // ready.
     function materialValidityCheck() {
         var bay = ((bayID == 1) ? bay1 : bay2)
-        if(bay.isMaterialValid) {
+        if(settings.getSkipFilamentNags || bay.isMaterialValid) {
             isMaterialValid = true
             return true
         }

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -81,7 +81,7 @@ MaterialPageForm {
         } else if(isExtruderFilamentPresent(extruderID)) {
             // Always allow purge and unload while paused
             return true
-        } else if(isUsingExpExtruder(extruderID)) {
+        } else if(isUsingExpExtruder(extruderID) || settings.getSkipFilamentNags) {
             // Allow loading mid-print for experimental extruders without any material checks
             return true
         } else {

--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -79,10 +79,13 @@ PrintPageForm {
         }
 
         if(startPrintUnknownSliceGenuineMaterial ||
-           startPrintGenuineSliceUnknownMaterial ||
-           startPrintMaterialMismatch ||
            startPrintWithInsufficientModelMaterial ||
-           startPrintWithInsufficientSupportMaterial) {
+           startPrintWithInsufficientSupportMaterial ||
+           (!settings.getSkipFilamentNags &&
+            (startPrintGenuineSliceUnknownMaterial ||
+            startPrintMaterialMismatch
+           ))
+        ) {
             return false
         }
         else {

--- a/src/settings_interface/settings_interface.cpp
+++ b/src/settings_interface/settings_interface.cpp
@@ -76,6 +76,10 @@ void SettingsInterface::setLanguageCode(const QString language_code) {
     writeSettings();
 }
 
+bool SettingsInterface::getSkipFilamentNags() {
+    return cached_settings_["skip_filament_nags"].asBool();
+}
+
 bool SettingsInterface::getAllowInternalStorage() {
     return cached_settings_["allow_internal_storage"].asBool();
 }

--- a/src/settings_interface/settings_interface.h
+++ b/src/settings_interface/settings_interface.h
@@ -32,6 +32,7 @@ class SettingsInterface : public QObject {
       SettingsInterface();
       Q_INVOKABLE QString getLanguageCode();
       Q_INVOKABLE bool getAllowInternalStorage();
+      Q_INVOKABLE bool getSkipFilamentNags();
       Q_INVOKABLE void setLanguageCode(const QString language_code);
       Q_INVOKABLE void setAllowInternalStorage(bool allow);
   private:


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-5075

In order to allow internal developers to move forward with development of
not-yet-existing combinations of materials and extruders, these changes
will allow several filament mismatch nags to be ignored - similar to what
experimental extruders would allow.

==========--------------------==========

Test script for testing BW-5075 patch on v1 Method

A) add new value to ui_settings.json
    1) connect to your v1 Method's internal file system via TTL or SSH
    2) add an entry to /home/settings/ui_settings.json
        a. add a comma to the end of the file's last entry
        b. add the below line:
                "skip_filament_nags": true

B) disable the popup that blocks all UI interaction when an extruder is in
   the "wrong slot"
    1) setup
        a. have available:
           * v1 material extruder
           * v1 support extruder
           * v2 support extruder
        b. unload and remove both extruders from carriage
    2) insert v1 support extruder into material extruder slot
        a. [ ] confirm no popup
    3) remove support extruder from material extruder slot
    4) insert v1 material extruder into support extruder slot
        a. [ ] confirm no popup
    5) remove material extruder from support extruder slot
    6) insert V1 material extruder into material extruder slot
    7) insert V2 support extruder into support extruder slot
        a. [ ] confirm no popup

C) allow side loading of materials for all extruder types, allow prints to
   start with incorrect materials loaded, and allow mid-print loading of
   mismatched materials
    1) setup
        a. have available:
            * simple test item sliced for v1
            * v1 material and support extruders
            * filament not compatible with extruder (suggestion: use compatible
              filament with a core indicating an incompatible material) and/or
              material set when slicing
            * support filament compatible with v1
        b. ensure unloaded v1 extruder is in the material slot
        c. load compatible support material into support extruder
    2) place "incompatible" material in Spool Drawer 1, and feed about 6 inches
       of filament into drawer funnel
    3) in the UI, select "Materials > Material > Load" to begin loading of
       incompatible filament
        a. [ ] confirm no issues loading material
    4) begin your test item print
        a. let ~30 sec. of extruding elapse
        b. [ ] confirm no issues starting print with "incompatible" material
    5) "switch" materials
        a. pause print
        b. "change material > unload"
        c. detach the filament guide nozzle to access the end of the unloaded
           filament
        d. use cutter to snip off end of filament
        e. back filament so it does not extend past filament guide nozzle
        f. reseat filament guide nozzle
    6) load "incompatible" material
        a. in the UI, select "Load"
        b. [ ] confirm no issues loading material
    7) continue your test print
        a. let ~10 sec. of extruding elapse
        b. [ ] confirm no issues continuing print with "incompatible" material
    8) print job may be cancelled

D) removal of new file setting
    2) remove entry from /home/settings/ui_settings.json
        a. remove the below line:
                "skip_filament_nags": true
        b. remove trailing comma before the removed value