### PR TITLE
Adds popup for moisture sensitive materials

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -261,6 +261,41 @@ Item {
               filamentMaterialName == "UNKNOWN"
     }
 
+    property var moistureSensitiveMaterialsList: {
+        switch(filamentBayID) {
+        case 1:
+            switch (bot.extruderAType) {
+            case ExtruderType.MK14:
+                ["NYLON", "NYLON CF"]
+                break;
+            default:
+                []
+                break;
+            }
+            break;
+        case 2:
+            switch (bot.extruderBType) {
+            case ExtruderType.MK14:
+                ["PVA"]
+                break;
+            default:
+                []
+                break;
+            }
+            break;
+        default:
+            []
+            break;
+    }
+
+    property bool isMaterialMoistureSensitive: {
+        (usingExperimentalExtruder ||
+         settings.getSkipFilamentNags) ?
+            false :
+                moistureSensitiveMaterialsList.indexOf(
+                    filamentMaterialName) >= 0
+    }
+
     property bool isMaterialValid: {
         (usingExperimentalExtruder ||
          settings.getSkipFilamentNags) ?

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -297,6 +297,12 @@ ApplicationWindow {
     }
     property bool experimentalExtruderAcknowledged: false
 
+    property bool moistureSensitiveMaterialDetected: {
+        (materialPage.bay1.isMaterialMoistureSensitive ||
+         materialPage.bay2.isMaterialMoistureSensitive
+    }
+    property bool materialMoistureWarningAcknowledged: false
+
     Item {
         id: rootItem
         smooth: false
@@ -2972,6 +2978,62 @@ ApplicationWindow {
                              "are calibrated before printing. The Experimental Extruder is\n" +
                              "an experimental product and is not covered under warranty\n" +
                              "or MakerCare."
+                            )
+                    }
+                    horizontalAlignment: Text.AlignHCenter
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    font.weight: Font.Light
+                    wrapMode: Text.WordWrap
+                    font.family: defaultFont.name
+                    font.pixelSize: 18
+                    font.letterSpacing: 1
+                    lineHeight: 1.3
+                }
+            }
+        }
+
+        CustomPopup {
+            id: materialMoistureWarningPopup
+            popupWidth: 720
+            popupHeight: 305
+            visible: !materialMoistureWarningAcknowledged &&
+                     moistureSensitiveMaterialDetected
+            showOneButton: true
+            full_button_text: qsTr("OK")
+            full_button.onClicked: {
+                materialMoistureWarningAcknowledged = true
+                materialMoistureWarningPopup.close()
+            }
+
+            ColumnLayout {
+                id: columnLayout_moist_warn_popup
+                width: 590
+                height: children.height
+                spacing: 25
+                anchors.top: parent.top
+                anchors.topMargin: 120
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                Text {
+                    id: alert_text_moist_warn_popup
+                    color: "#cbcbcb"
+                    text: qsTr("MOISTURE SENSITIVE MATERIAL DETECTED")
+                    font.letterSpacing: 3
+                    Layout.alignment: Qt.AlignHCenter
+                    font.family: defaultFont.name
+                    font.weight: Font.Bold
+                    font.pixelSize: 20
+                }
+
+                Text {
+                    id: description_text_moist_warn_popup
+                    color: "#cbcbcb"
+                    text: {
+                        qsTr("Some material is prone to absorbing moisture from the air. If exposed for\n" +
+                             "more than 15 minutes, you may need to run the material drying routine\n" +
+                             "located in settings to the material. After it is dry, always keep the\n" +
+                             "material in the material bay, an airtight bag or case"
                             )
                     }
                     horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-5138

Copied the Labs extruder acknowledgement popup, then modified it to
reflect the needs of the moisture sensitive materials acknowledgement.

Interfaces with filament bay rfid via a flag.

NOTE: Requires physical test and confirmation of functionality, as I
do not have a Method to run this code.