### PR TITLE
Revise material/machine error handling to be based on the material as…

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import ExtruderTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
+import MachineTypeEnum 1.0
 
 Item {
     id: filamentBayBaseItem
@@ -300,7 +301,13 @@ Item {
                 ["ABS", "ASA", "PC-ABS", "PC-ABS-FR"]
                 break;
             case ExtruderType.MK14_COMP:
-                ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON CF", "NYLON-12 CF", "ABS", "ASA", "PC-ABS", "PC-ABS FR"]
+                if(bot.machineType == MachineType.Fire) {
+                    ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON CF", "NYLON-12 CF"]
+                } else if(bot.machineType == MachineType.Lava) {
+                    ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON CF", "NYLON-12 CF", "ABS", "ASA", "PC-ABS", "PC-ABS FR"]
+                } else {
+                    []
+                }
                 break;
             default:
                 []

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -684,7 +684,7 @@ Item {
                                     qsTr("Only ABS and ASA model material are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
                                     break;
                                 case ExtruderType.MK14_COMP:
-                                    qsTr("Only NYLON CF model material is compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
+                                    qsTr("Only %1 model materials are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.").arg(materialPage.bay1.goodMaterialsList.join(", "))
                                     break;
                                 }
                             } else if(loadUnloadFilamentProcess.currentActiveTool == 2) {


### PR DESCRIPTION
… opposed to the extruder

- For the composite extruder, we are planning to allow it to print all model materials, dependent upon which machine it is placed in.

BW-5194
http://makerbot.atlassian.net/browse/BW-5194