### PR TITLE
set a default value for the skip-filament-nags flag

### DIFF
--- a/settings/ui_settings.json
+++ b/settings/ui_settings.json
@@ -1,4 +1,5 @@
 {
     "allow_internal_storage": false,
-    "language_code": "en_GB"
+    "language_code": "en_GB",
+    "skip_filament_nags": false
 }


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-5075

Modified ui_setting.json to include a default "false" value for the
skip-filament-nags flag, in response to Walter's encountering system
behavior that appeared to interpret the lack of an explicit default value
as "true", causing unintended behavior.