### PR TITLE
Change order of assignment per the dependency in date time page

### DIFF
--- a/src/qml/DateSelectorForm.qml
+++ b/src/qml/DateSelectorForm.qml
@@ -40,9 +40,11 @@ Item {
         var current_month = date_split[1] // 09
         var current_day = date_split[2] //10
 
-        dateTumbler.currentIndex = parseInt(current_day, 10) - 1
-        monthTumbler.currentIndex = parseInt(current_month, 10) - 1
+        // Days count depends on month & year, so they should be assigned
+        // first to not affect the date tumbler.
         yearTumbler.currentIndex = parseInt(current_year, 10) - 2000
+        monthTumbler.currentIndex = parseInt(current_month, 10) - 1
+        dateTumbler.currentIndex = parseInt(current_day, 10) - 1
     }
 
     function formatText(count, modelData) {


### PR DESCRIPTION
Changing month and year can change the date tumbler count(31/30/28/29)
which will end up resetting its position, so date tumbler position should
be set after setting month and year. Also, the date tumbler might not have
the 29th day to set itself to until the year is set.