### PR TITLE
FW 1.7: Leveling Issues

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -53,6 +53,7 @@ class ProcessModel : public BaseModel {
         LevelingLeft,
         LevelingRight,
         LevelingComplete,
+        LevelingFailed,
         CheckNozzleClean, // Toolhead calibration states
         HeatingNozzle,
         CleanNozzle,

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -126,6 +126,8 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
             stateTypeSet(ProcessStateType::LevelingRight);
         else if (kStepStr == "finishing_level")
             stateTypeSet(ProcessStateType::LevelingComplete);
+        else if (kStepStr == "finishing_level_fail")
+            stateTypeSet(ProcessStateType::LevelingFailed);
         // Toolhead Calibration States
         // see morepork-kaiten/kaiten/src/kaiten/processes/nozzlecalibrationprocess.py
         else if (kStepStr == "check_if_nozzle_clean")

--- a/src/qml/AssistedLevelingForm.qml
+++ b/src/qml/AssistedLevelingForm.qml
@@ -40,6 +40,9 @@ Item {
                         }
                     }
                     break;
+                case ProcessStateType.LevelingFailed:
+                    state = "leveling_failed"
+                    break;
                 case ProcessStateType.Cancelling:
                     state = "cancelling"
                     break;


### PR DESCRIPTION
- The UI leveling was not taking into account a failed leveling state
  without any error codes. It is possible for the leveling process
  on kaiten side to go into a failed leveling state when it has expired
  checking levelness without success.
- Now including the finishing_level_fail step on the UI side.

BW-5205
http://makerbot.atlassian.net/browse/BW-5205