### PR TITLE
Fixes for Qt 5.12

### DIFF
--- a/src/qml/AdvancedInfoCalibrationItemForm.qml
+++ b/src/qml/AdvancedInfoCalibrationItemForm.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.3
 
 Item {
     width: 800
-    height: 200
+    height: 180
 
     ColumnLayout {
         anchors.bottomMargin: 10
@@ -23,8 +23,6 @@ Item {
         RowLayout {
             id: calibration_rowLayout
             spacing: 0
-            anchors.top: heading.bottom
-            anchors.topMargin: 15
 
             AdvancedInfoCalibrationElement {
                 id: toolheadA

--- a/src/qml/AdvancedInfoChamberItemForm.qml
+++ b/src/qml/AdvancedInfoChamberItemForm.qml
@@ -8,8 +8,8 @@ Item {
 
     ColumnLayout {
         id: columnLayout
-        anchors.bottomMargin: 40
-        spacing: -1.5
+        anchors.bottomMargin: 30
+        spacing: 0
         anchors.fill: parent
 
         Text {

--- a/src/qml/AdvancedInfoFilamentBaysItemForm.qml
+++ b/src/qml/AdvancedInfoFilamentBaysItemForm.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.3
 
 Item {
     width: 800
-    height: 300
+    height: 320
 
     ColumnLayout {
         anchors.bottomMargin: 30
@@ -23,8 +23,6 @@ Item {
         RowLayout {
             id: filamentBays_rowLayout
             spacing: 0
-            anchors.top: heading.bottom
-            anchors.topMargin: 15
 
             AdvancedInfoFilamentBayElement {
                 id: filamentBayA

--- a/src/qml/AdvancedInfoMiscItemForm.qml
+++ b/src/qml/AdvancedInfoMiscItemForm.qml
@@ -19,8 +19,8 @@ Item {
     ColumnLayout {
         id: columnLayout
         anchors.top: heading.bottom
-        anchors.topMargin: 10
-        spacing: -2
+        anchors.topMargin: 15
+        spacing: 0
 
         AdvancedInfoElement {
             id: doorActivatedProperty

--- a/src/qml/AdvancedInfoMotionStatusItemForm.qml
+++ b/src/qml/AdvancedInfoMotionStatusItemForm.qml
@@ -8,8 +8,8 @@ Item {
 
     ColumnLayout {
         id: columnLayout
-        anchors.bottomMargin: 40
-        spacing: -1.5
+        anchors.bottomMargin: 30
+        spacing: 0
         anchors.fill: parent
 
         Text {

--- a/src/qml/AdvancedInfoToolheadsItemForm.qml
+++ b/src/qml/AdvancedInfoToolheadsItemForm.qml
@@ -4,10 +4,10 @@ import QtQuick.Layouts 1.3
 
 Item {
     width: 800
-    height: 400
+    height: 380
 
     ColumnLayout {
-        anchors.topMargin: 10
+        anchors.bottomMargin: 30
         anchors.fill: parent
 
         Text {
@@ -23,8 +23,6 @@ Item {
         RowLayout {
             id: toolheads_rowLayout
             spacing: 0
-            anchors.top: heading.bottom
-            anchors.topMargin: 15
 
             AdvancedInfoToolheadElement {
                 id: toolheadA

--- a/src/qml/ColorSelectorBoxForm.qml
+++ b/src/qml/ColorSelectorBoxForm.qml
@@ -6,7 +6,6 @@ Item {
     id: colorItem
     width: 400
     height: 100
-    anchors.horizontalCenter: parent.horizontalCenter
 
     property alias colorText: colorText.text
     property alias value: colorSpinBox.value

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -116,42 +116,42 @@ Item {
     property string filamentColor: {
         if(usingExperimentalExtruder) {
             expExtruderColor
-            return;
-        }
-        switch(filamentBayID) {
-        case 1:
-            Qt.rgba(bot.spoolAColorRGB[0]/255,
-                    bot.spoolAColorRGB[1]/255,
-                    bot.spoolAColorRGB[2]/255)
-            break;
-        case 2:
-            Qt.rgba(bot.spoolBColorRGB[0]/255,
-                    bot.spoolBColorRGB[1]/255,
-                    bot.spoolBColorRGB[2]/255)
-            break;
-        default:
-            "#000000"
-            break;
+        } else {
+            switch(filamentBayID) {
+            case 1:
+                Qt.rgba(bot.spoolAColorRGB[0]/255,
+                        bot.spoolAColorRGB[1]/255,
+                        bot.spoolAColorRGB[2]/255)
+                break;
+            case 2:
+                Qt.rgba(bot.spoolBColorRGB[0]/255,
+                        bot.spoolBColorRGB[1]/255,
+                        bot.spoolBColorRGB[2]/255)
+                break;
+            default:
+                "#000000"
+                break;
+            }
         }
     }
 
     property int filamentPercent: {
         if(usingExperimentalExtruder) {
             100
-            return;
-        }
-        switch(filamentBayID) {
-        case 1:
-            (bot.spoolAAmountRemaining/
-            bot.spoolAOriginalAmount) * 100
-            break;
-        case 2:
-            (bot.spoolBAmountRemaining/
-            bot.spoolBOriginalAmount) * 100
-            break;
-        default:
-            0
-            break;
+        } else {
+            switch(filamentBayID) {
+            case 1:
+                (bot.spoolAAmountRemaining/
+                bot.spoolAOriginalAmount) * 100
+                break;
+            case 2:
+                (bot.spoolBAmountRemaining/
+                bot.spoolBOriginalAmount) * 100
+                break;
+            default:
+                0
+                break;
+            }
         }
     }
 
@@ -499,6 +499,7 @@ Item {
                     id: filament_icon
                     filamentBayID: filamentBayBaseItem.filamentBayID
                     opacity: spoolPresent ? 1 : 0
+                    Layout.alignment: Qt.AlignVCenter
                 }
 
                 Text {

--- a/src/qml/FilamentIconForm.qml
+++ b/src/qml/FilamentIconForm.qml
@@ -5,7 +5,6 @@ Item {
     width: 22
     height: 22
     smooth: false
-    anchors.verticalCenter: parent.verticalCenter
 
     property int filamentBayID: 0
     property bool spoolPresent: {

--- a/src/qml/MaterialIconForm.qml
+++ b/src/qml/MaterialIconForm.qml
@@ -47,15 +47,15 @@ Item {
                                 parent.fillPercent*0.06283185, false);
                     context.lineTo(centreX, centreY);
                     context.fill();
-                    return;
+                } else {
+                    //0.06283185 = PI*2/100
+                    context.arc(centreX, centreY, parent.width*0.40, 0,
+                                parent.fillPercent*0.06283185, false);
+                    context.lineWidth = 12;
+                    context.lineCap = "round";
+                    context.strokeStyle = parent.fillColor;
+                    context.stroke()
                 }
-                //0.06283185 = PI*2/100
-                context.arc(centreX, centreY, parent.width*0.40, 0,
-                            parent.fillPercent*0.06283185, false);
-                context.lineWidth = 12;
-                context.lineCap = "round";
-                context.strokeStyle = parent.fillColor;
-                context.stroke()
             }
         }
     }

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -1803,7 +1803,6 @@ ApplicationWindow {
 
                     TitleText {
                         text: qsTr("WRONG EXTRUDER TYPE DETECTED")
-                        anchors.horizontalCenter: parent.horizontalCenter
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     }
                     BodyText{
@@ -1842,7 +1841,6 @@ ApplicationWindow {
                                 }
                             }
                         }
-                        anchors.horizontalCenter: parent.horizontalCenter
                         horizontalAlignment: Text.AlignHCenter
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -1873,7 +1871,6 @@ ApplicationWindow {
 
                     TitleText {
                         text: "CARRIAGE COMMUNICATION ERROR"
-                        anchors.horizontalCenter: parent.horizontalCenter
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     }
                     BodyText{
@@ -1882,7 +1879,6 @@ ApplicationWindow {
                             "Try restarting the printer. If this happens again, please\n"+
                             "contact MakerBot support."
                         }
-                        anchors.horizontalCenter: parent.horizontalCenter
                         horizontalAlignment: Text.AlignHCenter
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
@@ -1981,6 +1977,14 @@ ApplicationWindow {
                                 mainSwipeView.swipeToItem(3)
                                 settingsPage.settingsSwipeView.swipeToItem(6)
                             }
+                            onPressed: {
+                                calib_text.color = "#000000"
+                                calib_rectangle.color = "#ffffff"
+                            }
+                            onReleased: {
+                                calib_text.color = "#ffffff"
+                                calib_rectangle.color = "#00000000"
+                            }
                         }
                     }
 
@@ -2012,26 +2016,29 @@ ApplicationWindow {
                             onClicked: {
                                 extNotCalibratedPopup.close()
                             }
+                            onPressed: {
+                                cancel_calib_text.color = "#000000"
+                                cancel_calib_rectangle.color = "#ffffff"
+                            }
+                            onReleased: {
+                                cancel_calib_text.color = "#ffffff"
+                                cancel_calib_rectangle.color = "#00000000"
+                            }
                         }
                     }
                 }
                 ColumnLayout {
+                    height: 140
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    height: 150
-                    anchors.top: parent.top
+                    anchors.verticalCenterOffset: -20
 
                     TitleText {
-                        anchors.top: parent.top
-                        anchors.topMargin: 40
                         font.weight: Font.Bold
                         text: "CALIBRATION REQUIRED"
-                        anchors.horizontalCenter: parent.horizontalCenter
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     }
                     BodyText {
-                        anchors.top: parent.top
-                        anchors.topMargin: 90
                         font.weight: Font.Light
                         wrapMode: Text.WordWrap
                         font.family: defaultFont.name
@@ -2043,7 +2050,6 @@ ApplicationWindow {
                             "Be sure the extruders are latched into place "+
                             "before\ncalibrating."
                         }
-                        anchors.horizontalCenter: parent.horizontalCenter
                         horizontalAlignment: Text.AlignHCenter
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter

--- a/src/qml/NotificationIconsForm.qml
+++ b/src/qml/NotificationIconsForm.qml
@@ -19,7 +19,6 @@ Item {
             width: 35
             height: 26
             smooth: false
-            anchors.verticalCenter: parent.verticalCenter
             opacity: isFreComplete || currentFreStep >= FreStep.AttachExtruders
 
             FilamentIcon {
@@ -28,6 +27,7 @@ Item {
                 anchors.left: parent.left
                 anchors.leftMargin: 5
                 filamentBayID: 1
+                anchors.verticalCenter: parent.verticalCenter
             }
 
             FilamentIcon {
@@ -35,6 +35,7 @@ Item {
                 anchors.left: parent.left
                 anchors.leftMargin: 20
                 filamentBayID: 2
+                anchors.verticalCenter: parent.verticalCenter
             }
         }
 
@@ -43,7 +44,6 @@ Item {
             width: 26
             height: 26
             smooth: false
-            anchors.verticalCenter: parent.verticalCenter
 
             Image {
                 id: connection_type_image

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -372,7 +372,6 @@ Item {
                     height: 100
                     smooth: false
                     spacing: 65
-                    anchors.top: divider_item1.bottom
 
                     ColumnLayout {
                         id: columnLayout1

--- a/src/qml/ReviewTestPrintPageForm.qml
+++ b/src/qml/ReviewTestPrintPageForm.qml
@@ -42,13 +42,10 @@ Item {
             font.family: defaultFont.name
             font.pixelSize: 20
             lineHeight: 1.5
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 100
         }
 
         Item {
             id: buttons_item
-            anchors.fill: parent
 
             RoundedButton {
                 id: calibrate_button

--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -483,11 +483,11 @@ Item {
 
                 TitleText {
                     text: qsTr("SHUT DOWN PRINTER")
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 }
                 BodyText{
                     text: qsTr("Are you sure you want to shut down the printer?")
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 }
             }
         }

--- a/src/qml/SignInPageForm.qml
+++ b/src/qml/SignInPageForm.qml
@@ -307,6 +307,7 @@ Item {
                         id: showPassword
                         checked: false
                         onPressed: passwordField.forceActiveFocus()
+                        Layout.alignment: Qt.AlignLeft
                     }
 
                     Text {
@@ -317,13 +318,13 @@ Item {
                         color: "#ffffff"
                         font.family: defaultFont.name
                         font.weight: Font.Light
-                        anchors.left: showPassword.right
+                        Layout.alignment: Qt.AlignLeft
                     }
 
                     Button {
                         id: forgotPasswordButton
-                        anchors.right: rowLayout.right
                         padding: 0
+                        Layout.alignment: Qt.AlignRight
 
                         contentItem: Text {
                             text: qsTr("Forgot Password?")

--- a/src/qml/SpoolInfoColumnForm.qml
+++ b/src/qml/SpoolInfoColumnForm.qml
@@ -23,13 +23,10 @@ Item {
     ColumnLayout {
         Text {
             id: title
-
             text: ""
             color: "#ffffff"
             font.letterSpacing: 1
             font.bold: true
-            anchors.horizontalCenterOffset: 0
-            anchors.horizontalCenter: parent.horizontalCenter
             font.pixelSize: 15
         }
 

--- a/src/qml/SpoolInfoPageForm.qml
+++ b/src/qml/SpoolInfoPageForm.qml
@@ -25,13 +25,11 @@ Item {
         SpoolInfoColumn {
             id: spoolAInfo
             index: 0
-            anchors.top: parent.top
         }
 
         SpoolInfoColumn {
             id: spoolBInfo
             index: 1
-            anchors.top: parent.top
         }
     }
 }

--- a/src/qml/StartPrintMaterialIconForm.qml
+++ b/src/qml/StartPrintMaterialIconForm.qml
@@ -112,19 +112,19 @@ Item {
             visible: {
                 if(isLabsMaterial) {
                     false
-                    return;
+                } else {
+                    switch(filamentBayID) {
+                    case 1:
+                        bot.filamentBayATagPresent
+                        break;
+                    case 2:
+                        bot.filamentBayBTagPresent
+                        break;
+                    default:
+                        false
+                        break;
+                    }
                 }
-                switch(filamentBayID) {
-                     case 1:
-                         bot.filamentBayATagPresent
-                         break;
-                     case 2:
-                         bot.filamentBayBTagPresent
-                         break;
-                     default:
-                         false
-                         break;
-                     }
             }
             onPaint: {
                 var context = getContext("2d");

--- a/src/qml/StartPrintPageForm.qml
+++ b/src/qml/StartPrintPageForm.qml
@@ -260,7 +260,6 @@ Item {
                     height: 100
                     smooth: false
                     spacing: 30
-                    anchors.top: divider_item1.bottom
 
                     ColumnLayout {
                         id: columnLayout1


### PR DESCRIPTION
1.) Assignment expression for properties cannot have return statement
2.) Children of auto-layout elements like ColumnLayout, RowLayout
cannot specify precise positioning. They can only request broad
positioning like AlignLeft, Center, Right etc.