### PR TITLE
Fix material checks

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -26,7 +26,7 @@ ErrorScreenForm {
     }
 
     function loadPurgeFromErrorScreen() {
-        if(isExtruderAError() && (materialPage.bay1.usingExperimentalExtruder || settings.getSkipFilamentNags)) {
+        if(isExtruderAError() && (materialPage.bay1.usingExperimentalExtruder || settings.getSkipFilamentNags())) {
             materialPage.isLoadFilament = true
             materialPage.materialSwipeView.swipeToItem(1)
             return;

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -260,14 +260,14 @@ Item {
 
     property bool isUnknownMaterial: {
         (usingExperimentalExtruder ||
-         settings.getSkipFilamentNags) ?
+         settings.getSkipFilamentNags()) ?
               false :
               filamentMaterialName == "UNKNOWN"
     }
 
     property bool isMaterialValid: {
         (usingExperimentalExtruder ||
-         settings.getSkipFilamentNags) ?
+         settings.getSkipFilamentNags()) ?
               true :
               (goodMaterialsList.indexOf(filamentMaterialName) >= 0)
     }

--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -81,7 +81,7 @@ MaterialPageForm {
         } else if(isExtruderFilamentPresent(extruderID)) {
             // Always allow purge and unload while paused
             return true
-        } else if(isUsingExpExtruder(extruderID) || settings.getSkipFilamentNags) {
+        } else if(isUsingExpExtruder(extruderID) || settings.getSkipFilamentNags()) {
             // Allow loading mid-print for experimental extruders without any material checks
             return true
         } else {

--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -31,7 +31,7 @@ PrintPageForm {
         // Single extruder prints
         if(model_extruder_used && !support_extruder_used) {
             if (materialPage.bay1.usingExperimentalExtruder ||
-                settings.getSkipFilamentNags) {
+                settings.getSkipFilamentNags()) {
                 // Empty case, flag no errors!
             } else if(materialPage.bay1.filamentMaterialName.toLowerCase() !=
                     print_model_material) {
@@ -62,7 +62,7 @@ PrintPageForm {
             // Since slices aren't
             if((!modelMaterialOK && // Skip model checking if approved earlier
                 !materialPage.bay1.usingExperimentalExtruder && // Skip model checking if exp. extruder used
-                !settings.getSkipFilamentNags && // Skip model checking if internal developers are trying something
+                !settings.getSkipFilamentNags() && // Skip model checking if internal developers are trying something
                  materialPage.bay1.filamentMaterialName.toLowerCase() != print_model_material) ||
                 (materialPage.bay2.filamentMaterialName.toLowerCase() != print_support_material)) {
                 startPrintMaterialMismatch = true


### PR DESCRIPTION
The typo made the call always return true making the printer operate as
if a labs extruder was installed, skipping all material checks.