### PR TITLE
Fit all material names into material icon

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -416,6 +416,13 @@ Item {
             font.pixelSize: 18
             smooth: false
             antialiasing: false
+            scale: {
+                if(width > 125) {
+                    0.75
+                } else {
+                    1
+                }
+            }
         }
 
         ColumnLayout {


### PR DESCRIPTION
Would be nice to make this dynamic in the future and use maximum possible
size instead of constant scaling.