### PR TITLE
Add support for magma

### DIFF
--- a/settings/CMakeLists.txt
+++ b/settings/CMakeLists.txt
@@ -1,12 +1,3 @@
-# Copy over the settings file and then install it
-function(install_settings machine_name)
-    configure_file(${CMAKE_SOURCE_DIR}/settings/ui_settings.json
-      ${CMAKE_CURRENT_BINARY_DIR}/${machine_name}/ui_settings.json COPYONLY)
-    install(
-        FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/${machine_name}/ui_settings.json"
-        DESTINATION
-            per_machine/${machine_name}/${USER_EDITABLE_CONFIG_INSTALL_DIR})
-endfunction()
-
-install_settings(fire dual lava)
+install(
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/ui_settings.json"
+    DESTINATION "${USER_EDITABLE_CONFIG_INSTALL_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,12 @@ if(NOT ${QT_CREATOR_BUILD})
         DIRECTORY "${MoreporkUI_SOURCE_DIR}/test_prints/lava/"
 	    DESTINATION
             "${CMAKE_INSTALL_PREFIX}/per_machine/lava/rootfs/usr/test_prints")
+    # TODO(chris) Actually make test prints for magma.  These won't actually
+    #             print so we will hopefully catch this before shipping...
+    install(
+        DIRECTORY "${MoreporkUI_SOURCE_DIR}/test_prints/lava/"
+	    DESTINATION
+            "${CMAKE_INSTALL_PREFIX}/per_machine/magma/rootfs/usr/test_prints")
 endif()
 
 # Read qml qrc file, parse out all qml file names, and install them

--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -19,7 +19,8 @@ class BotModel : public BaseModel {
     // MOREPORK_QML_ENUM
     enum MachineType {
         Fire,
-        Lava
+        Lava,
+        Magma
     };
 
     // MOREPORK_QML_ENUM

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -1389,6 +1389,8 @@ void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {
             machineTypeSet(MachineType::Fire);
         } else if (kMachineTypeStr == "lava") {
             machineTypeSet(MachineType::Lava);
+        } else if (kMachineTypeStr == "magma") {
+            machineTypeSet(MachineType::Magma);
         } else {
             machineTypeReset();
         }

--- a/src/qml/AnnealPrintForm.qml
+++ b/src/qml/AnnealPrintForm.qml
@@ -183,6 +183,8 @@ Item {
                 annealPartTemperatureListMethod
             } else if(bot.machineType == MachineType.Lava) {
                 annealPartTemperatureListMethodX
+            } else if(bot.machineType == MachineType.Magma) {
+                annealPartTemperatureListMethodX
             }
         }
 

--- a/src/qml/DryMaterialSelectorForm.qml
+++ b/src/qml/DryMaterialSelectorForm.qml
@@ -17,6 +17,8 @@ ListView {
             dryingMaterialsListMethod
         } else if(bot.machineType == MachineType.Lava) {
             dryingMaterialsListMethodX
+        } else if(bot.machineType == MachineType.Magma) {
+            dryingMaterialsListMethodX
         }
     }
 

--- a/src/qml/ExtruderPageForm.qml
+++ b/src/qml/ExtruderPageForm.qml
@@ -432,7 +432,7 @@ Item {
                             if(itemAttachExtruder.extruder == 1) {
                                 if(bot.machineType == MachineType.Fire) {
                                     qsTr("Insert a Model 1A or 1C Extruder into\nSlot 1")
-                                } else if(bot.machineType == MachineType.Lava) {
+                                } else {
                                     qsTr("Insert a Model 1A, 1X or 1C Extruder into\nSlot 1")
                                 }
                             } else if(itemAttachExtruder.extruder == 2) {
@@ -444,7 +444,7 @@ Item {
                                           bot.extruderAType == ExtruderType.MK14_COMP) {
                                     if(bot.machineType == MachineType.Fire) {
                                         qsTr("Insert a Support 2A Extruder into\nSlot 2")
-                                    } else if(bot.machineType == MachineType.Lava) {
+                                    } else {
                                         qsTr("Insert a Support 2A or 2X Extruder into\nSlot 2")
                                     }
                                 }

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -303,10 +303,8 @@ Item {
             case ExtruderType.MK14_COMP:
                 if(bot.machineType == MachineType.Fire) {
                     ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF"]
-                } else if(bot.machineType == MachineType.Lava) {
-                    ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF", "ABS", "ASA", "PC-ABS", "PC-ABS-FR"]
                 } else {
-                    []
+                    ["PLA", "Tough", "PETG", "ESD Tough", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF", "ABS", "ASA", "PC-ABS", "PC-ABS-FR"]
                 }
                 break;
             default:

--- a/src/qml/FirmwareFileListUsbForm.qml
+++ b/src/qml/FirmwareFileListUsbForm.qml
@@ -62,6 +62,10 @@ Item {
                     qsTr("Choose another folder or visit MakerBot.com/MethodXFW to\n" +
                         "download the latest firmware. Drag the file onto a usb\n" +
                         "stick and insert it into the front of the printer.")
+                } else if (bot.machineType == MachineType.Magma) {
+                    qsTr("Choose another folder or visit MakerBot.com/MethodXLFW to\n" +
+                        "download the latest firmware. Drag the file onto a usb\n" +
+                        "stick and insert it into the front of the printer.")
                 }
             }
             anchors.top: parent.bottom

--- a/src/qml/FirmwareUpdatePageForm.qml
+++ b/src/qml/FirmwareUpdatePageForm.qml
@@ -452,6 +452,8 @@ Item {
 
                     } else if (bot.machineType == MachineType.Lava) {
                         qsTr("Visit MakerBot.com/MethodXFW to download the latest firmware. Drag the file onto a usb stick and insert it into the front of the printer.")
+                    } else if (bot.machineType == MachineType.Magma) {
+                        qsTr("Visit MakerBot.com/MethodXLFW to download the latest firmware. Drag the file onto a usb stick and insert it into the front of the printer.")
                     }
 
                 }

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -647,7 +647,7 @@ Item {
                     text: {
                         if(isMaterialMismatch) {
                             if (loadUnloadFilamentProcess.currentActiveTool == 1) {
-                                if (bot.machineType == MachineType.Lava &&
+                                if (bot.machineType != MachineType.Fire &&
                                         (materialPage.bay1.filamentMaterialName == "ABS" ||
                                          materialPage.bay1.filamentMaterialName == "ASA")) {
                                     qsTr("UNSUPPORTED MATERIAL DETECTED")
@@ -680,7 +680,7 @@ Item {
                                     // a V2 printer and the user tries to load a V2 hot extruder
                                     // specific material. This warning can be made generic for
                                     // all such materials.
-                                    if (bot.machineType == MachineType.Lava &&
+                                    if (bot.machineType != MachineType.Fire &&
                                         (materialPage.bay1.filamentMaterialName == "ABS" ||
                                          materialPage.bay1.filamentMaterialName == "ASA")) {
                                         qsTr("Only PLA, Tough and PETG model material are compatible with a Model 1A Extruder. Insert a Model 1XA Extruder to print ABS or ASA.")

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -275,6 +275,8 @@ ApplicationWindow {
             "Method"
         } else if (bot.machineType == MachineType.Lava) {
             "Method X"
+        } else if (bot.machineType == MachineType.Magma) {
+            "Method XL"
         }
     }
 
@@ -1836,7 +1838,7 @@ ApplicationWindow {
                                 } else {
                                     ""
                                 }
-                            } else if (bot.machineType == MachineType.Lava) {
+                            } else {
                                 // Hot bot (V2) supports both mk14 and mk14_hot extruders.
                                 if (wrongExtruderPopup.modelExtWrong) {
                                     qsTr("Please insert a Model 1A or Model 1XA Performance\n" +


### PR DESCRIPTION
BW-5213
http://makerbot.atlassian.net/browse/BW-5213

This supports parsing of a machine type of "magma" from kaiten.  This is mostly
done by replacing checks for "Lava" with checks for "not Fire", since we generally
expect the extruder support of Magma to be the same as Lava.  In a few places I
added magma as a separate case that did the same thing as lava as this potentially
seemed more appropriate, and when using this type for a product name I chose the
placeholder XL.  This also installs lava test prints to magma, just in case anything
we care about might break if there were no test prints.  The test prints should
refuse to print.

I also removed the current attempt at per machine settings files, since it was
completely broken and resulting in only V1 printers even getting a default settings
file.  There are not currently any per machine UI settings so I am not sure what
was even being attempted here.