### PR TITLE
Ensure current thing file parse is successful

### DIFF
--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -160,6 +160,12 @@ PrintPageForm {
         }
     }
 
+    function updateCurrentThing() {
+        if(storage.updateCurrentThing()) {
+            getPrintFileDetails(storage.currentThing)
+        }
+    }
+
     printingDrawer.buttonCancelPrint.onClicked: {
         printingDrawer.close()
         if(inFreStep) {

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -110,8 +110,7 @@ Item {
     property bool isPrintFileValid: bot.process.printFileValid
     onIsPrintFileValidChanged: {
         if(isPrintFileValid) {
-            storage.updateCurrentThing()
-            getPrintFileDetails(storage.currentThing)
+            updateCurrentThing()
             showPrintTip()
         }
     }
@@ -120,8 +119,7 @@ Item {
         id: getPrintDetailsTimer
         interval: 3000
         onTriggered: {
-            storage.updateCurrentThing()
-            getPrintFileDetails(storage.currentThing)
+            updateCurrentThing()
             this.stop()
         }
     }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -305,7 +305,7 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
 #endif
 }
 
-void MoreporkStorage::updateCurrentThing() {
+bool MoreporkStorage::updateCurrentThing() {
     const QString dir_path = CURRENT_THING_PATH;
     if(QDir(dir_path).exists()) {
         QDirIterator current_thing_dir(dir_path, QDir::Files |
@@ -318,11 +318,13 @@ void MoreporkStorage::updateCurrentThing() {
             }
             if(current_thing != nullptr) {
                 currentThingSet(current_thing);
+                return true;
             } else {
                 currentThingReset();
             }
         }
     }
+    return false;
 }
 
 

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -319,7 +319,7 @@ class MoreporkStorage : public QObject {
     QList<QObject*> printFileList() const;
     void printFileListSet(const QList<QObject*> &print_file_list);
     void printFileListReset();
-    Q_INVOKABLE void updateCurrentThing();
+    Q_INVOKABLE bool updateCurrentThing();
     Q_PROPERTY(PrintFileInfo* currentThing
       READ currentThing
       WRITE currentThingSet


### PR DESCRIPTION
There are three cases where a .makerbot file is parsed by the UI
backend. First when a print file is directly selected from the UI to
be printed. Next, when a print file is transferred from another client
like MB Print in which case the UI looks for the 'print_file_valid'
notification to know that the file is in place in the current thing
directory before parsing the metadata. The third case is when a print
is started from repl on a local file on the printer which is when the
UI has no direct means of knowing when to start parsing the file. The
easiest way was to look for the start of a print process and try to
read the .makerbot in the current thing directory after an arbitrary
time. This method worked fine in prior versions of Qt even though it
was most likley failing gracefully for print process started from
external clients since the file isn't in place when the read happens.

This commit ensures that the meta data read is successful before
attempting to read the print details object for both cases, print
from external client and print from repl. Prints initiated from UI
are unaffected by this change.

BW-5233
https://makerbot.atlassian.net/browse/BW-5233