### PR TITLE
Fix material name for ESD-Tough

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -231,7 +231,7 @@ Item {
             "ASA"
             break;
         case 10:
-            "ESD Tough"
+            "ESD-Tough"
             break;
         case 11:
             "NYLON"


### PR DESCRIPTION
An earlier [commit](https://github.com/makerbot/morepork-ui/pull/369/commits/b2024b35975179cf3fd1218f10b6a047387ec1cc) updated the name in the supported materials list only,
and not the display name. The display name is what is checked against the
material list for determining whether the material can be used with the
installed extruder, which here in this case made the material unusable.