### PR TITLE
Fit material name and color string in 1 line each in extruder page

### DIFF
--- a/src/qml/ExtruderForm.qml
+++ b/src/qml/ExtruderForm.qml
@@ -303,10 +303,9 @@ Item {
                 visible: extruderPresent
                 Text {
                     id: filamentMaterial_text
-                    Layout.maximumWidth: attachButton.width
+                    Layout.maximumWidth: 165
                     elide: Text.ElideRight
-                    maximumLineCount: 3
-                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                    maximumLineCount: 2
                     text: {
                         if(spoolPresent) {
                             switch(extruderID) {


### PR DESCRIPTION
Longer material names like nylon-12-cf were being cut in the middle
and wrapped into 2 lines.