### PR TITLE
Get bot serial during UI startup

### DIFF
--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -1890,6 +1890,7 @@ void KaitenBotModel::connected() {
     // TODO: Kaiten codegen?
     m_conn->jsonrpc.invoke("get_system_information", Json::Value(), m_sysInfoCb);
     m_conn->jsonrpc.invoke("network_state", Json::Value(), m_netStateCb);
+    m_conn->jsonrpc.invoke("handshake", Json::Value(), m_handshakeUpdateCb);
     // Get spool info for bay indicies 0 and 1
     Json::Value jval_param(Json::objectValue);
     for (int i = 0; i < 2; ++i) {

--- a/src/qml/AuthorizeAccountWithCode.qml
+++ b/src/qml/AuthorizeAccountWithCode.qml
@@ -2,7 +2,6 @@ import QtQuick 2.10
 
 AuthorizeAccountWithCodeForm {
     function beginAuthWithCode() {
-        bot.handshake()
         showConnectingPopup()
         network.onInitiateAuthWithCodeSucceeded.connect(getOTP)
         network.onCheckAuthWithCodeSucceeded.connect(authorized)


### PR DESCRIPTION
The bot serial is currently only used by the UI when requesting a one
time password for cloud authentication. The serial was populated just
before making the request and callback to update it doesn't seem to
be returning in time to update the serial, leading to the placeholder
iserial being sent to cloudauth server,  which itself somehow goes
through with it and successfully sends an otp back to the printer.
Subsequent requests had the serial variable correctly populated and
sent along with the otp request.

Also, the handshake call to update the serial isn't really specific to
cloudauth and the serial isn't going to change on every call for it to
live in the cloud auth workflow.

https://makerbot.atlassian.net/browse/BW-5303