### PR TITLE
Install UI settings file only for firmware build

### DIFF
--- a/settings/CMakeLists.txt
+++ b/settings/CMakeLists.txt
@@ -1,3 +1,5 @@
-install(
-    FILES "${CMAKE_CURRENT_SOURCE_DIR}/ui_settings.json"
-    DESTINATION "${USER_EDITABLE_CONFIG_INSTALL_DIR}")
+if(NOT ${QT_CREATOR_BUILD})
+    install(
+        FILES "${CMAKE_CURRENT_SOURCE_DIR}/ui_settings.json"
+        DESTINATION "${USER_EDITABLE_CONFIG_INSTALL_DIR}")
+endif()


### PR DESCRIPTION
The desktop qt build doesn't have the settings folder path macro defined
in cmake and we also have mechanism to refer to the local settings file
in the code when running the UI program on desktop.