### PR TITLE
Allow print from USB flash drive with Oyster

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -416,7 +416,8 @@ void MoreporkStorage::newSortType(){
 
 void MoreporkStorage::updateUsbStorageConnected(){
   const bool kUsbStorConnected = QFileInfo(USB_STORAGE_DEV_BY_PATH).exists() ||
-                      QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY).exists();
+            QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1).exists() ||
+            QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2).exists();
   const bool kUsbLegacyConnected = QFileInfo(LEGACY_USB_DEV_BY_PATH).exists();
   usbStorageConnectedSet(kUsbStorConnected || kUsbLegacyConnected);
   if (!kUsbStorConnected) {

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -22,7 +22,8 @@
 #define TEST_PRINT_PATH QString("/home/")+qgetenv("USER")+"/test_prints/"
 #define FIRMWARE_FOLDER_PATH QString("/home/")+qgetenv("USER")+"/firmware"
 #define USB_STORAGE_DEV_BY_PATH QString()
-#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY QString()
+#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1 QString()
+#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2 QString()
 #define LEGACY_USB_DEV_BY_PATH QString()
 #ifdef SETTINGS_FILE_DIR
 #define MACHINE_PID_PATH SETTINGS_FILE_DIR + std::string("/mock_PID")
@@ -36,8 +37,10 @@
 #define FIRMWARE_FOLDER_PATH QString("/home/firmware")
 #define USB_STORAGE_DEV_BY_PATH \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1:1.0-scsi-0:0:0:0")
-#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY \
+#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1 \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1.1:1.0-scsi-0:0:0:0")
+#define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2 \
+QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1.2:1.0-scsi-0:0:0:0")
 // TODO(chris): Remove this when we no longer need to support rev B boards
 #define LEGACY_USB_DEV_BY_PATH \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.4:1.0-scsi-0:0:0:0")


### PR DESCRIPTION
- Add another dev path for daisy chained hub in our oyster accesory.
- Allow usb flash drive support on both ports of accessory hub.
BW-5249
http://makerbot.atlassian.net/browse/BW-5249