### PR TITLE
Re-enable display of Buildplane vs Chamber temps

### DIFF
--- a/src/qml/AdvancedInfoChamberItemForm.qml
+++ b/src/qml/AdvancedInfoChamberItemForm.qml
@@ -31,14 +31,26 @@ Item {
 
         AdvancedInfoElement {
             id: currentTempProperty
-            label: qsTr("CURRENT TEMP.")
+            label: qsTr("CHAMBER CURR. TEMP.")
             value: bot.infoChamberCurrentTemp
         }
 
         AdvancedInfoElement {
             id: targetTempProperty
-            label: qsTr("TARGET TEMP.")
+            label: qsTr("CHAMBER TGT TEMP.")
             value: bot.infoChamberTargetTemp
+        }
+
+        AdvancedInfoElement {
+            id: buildplaneTempProperty
+            label: qsTr("BUILDPLANE CURR. TEMP.")
+            value: bot.buildplaneCurrentTemp
+        }
+
+        AdvancedInfoElement {
+            id: buildplaneTargetTempProperty
+            label: qsTr("BUILDPLANE TGT.")
+            value: bot.buildplaneTargetTemp
         }
 
         AdvancedInfoElement {

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -26,7 +26,7 @@ Item {
     property int num_shells
     property real layer_height_mm
     property string extruder_temp
-    property string chamber_temp
+    property string buildplane_temp
     property string slicer_name
     property string readyByTime
     property int lastPrintTimeSec
@@ -179,7 +179,7 @@ Item {
         num_shells = file.numShells
         extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + "C" :
                                               file.extruderTempCelciusA + "C" + " + " + file.extruderTempCelciusB + "C"
-        chamber_temp = file.chamberTempCelcius + "C"
+        buildplane_temp = file.buildplaneTempCelcius + "C"
         slicer_name = file.slicerName
         getPrintTimes(printTimeSec)
     }
@@ -201,7 +201,7 @@ Item {
         supportMaterialRequired = 0.0
         num_shells = ""
         extruder_temp = ""
-        chamber_temp = ""
+        buildplane_temp = ""
         slicer_name = ""
         startPrintWithUnknownMaterials = false
     }
@@ -639,9 +639,9 @@ Item {
                 }
 
                 InfoItem {
-                    id: printInfo_chamberTemperature
-                    labelText: qsTr("Chamber Temperature")
-                    dataText: chamber_temp
+                    id: printInfo_buildplaneTemperature
+                    labelText: qsTr("Buildplane Temperature")
+                    dataText: buildplane_temp
                 }
 
                 InfoItem {

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -263,7 +263,7 @@ Item {
                                      (qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp)) :
                                      "\n"))
                             } else {
-                                (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
+                                (qsTr("%1 C").arg(bot.buildplaneCurrentTemp) + " | " + qsTr("%1 C").arg(bot.buildplaneTargetTemp))
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -671,9 +671,9 @@ Item {
                         }
 
                         Text {
-                            id: chamber_temp_label
+                            id: buildplane_temp_label
                             color: "#cbcbcb"
-                            text: qsTr("CHAMBER TEMP")
+                            text: qsTr("BUILDPLANE TEMP")
                             antialiasing: false
                             smooth: false
                             font.pixelSize: 18
@@ -740,9 +740,9 @@ Item {
                         }
 
                         Text {
-                            id: chamber_temp_text
+                            id: buildplane_temp_text
                             color: "#ffffff"
-                            text: qsTr("%1C").arg(bot.chamberCurrentTemp)
+                            text: qsTr("%1C").arg(bot.buildplaneCurrentTemp)
                             antialiasing: false
                             smooth: false
                             font.family: defaultFont.name


### PR DESCRIPTION
http://makerbot.atlassian.net/browse/BW-5199

Short term solution for displaying buildplane temperatures, as the "correct" solution is to move temperature value filtering functions to a different data dictionary, machine_dict["chamber_status"], before the chamber_status dictionary is moved into the toolhead_status dictionary, since AdvancedInfoChamberForm.qml is mostly reading values from the pre-move version of the dictionary.

This patch only points ui elements to the post-move version, with polling rate issues associated with the differences in update rates to both versions of the data dictionaries.