### PR TITLE
re-hide buildplane temperature displays

### DIFF
--- a/src/qml/AdvancedInfoChamberItemForm.qml
+++ b/src/qml/AdvancedInfoChamberItemForm.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.3
 
 Item {
     width: 400
-    height: 300
+    height: 240
 
     ColumnLayout {
         id: columnLayout
@@ -31,26 +31,14 @@ Item {
 
         AdvancedInfoElement {
             id: currentTempProperty
-            label: qsTr("CHAMBER TEMP.")
+            label: qsTr("CURRENT TEMP.")
             value: bot.infoChamberCurrentTemp
         }
 
         AdvancedInfoElement {
             id: targetTempProperty
-            label: qsTr("CHAMBER TARGET")
+            label: qsTr("TARGET TEMP.")
             value: bot.infoChamberTargetTemp
-        }
-
-        AdvancedInfoElement {
-            id: buildplaneTempProperty
-            label: qsTr("BUILDPLANE TEMP.")
-            value: bot.buildplaneCurrentTemp
-        }
-
-        AdvancedInfoElement {
-            id: buildplaneTargetTempProperty
-            label: qsTr("BUILDPLANE TARGET")
-            value: bot.buildplaneTargetTemp
         }
 
         AdvancedInfoElement {

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -26,7 +26,7 @@ Item {
     property int num_shells
     property real layer_height_mm
     property string extruder_temp
-    property string buildplane_temp
+    property string chamber_temp
     property string slicer_name
     property string readyByTime
     property int lastPrintTimeSec
@@ -179,7 +179,7 @@ Item {
         num_shells = file.numShells
         extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + "C" :
                                               file.extruderTempCelciusA + "C" + " + " + file.extruderTempCelciusB + "C"
-        buildplane_temp = file.buildplaneTempCelcius + "C"
+        chamber_temp = file.chamberTempCelcius + "C"
         slicer_name = file.slicerName
         getPrintTimes(printTimeSec)
     }
@@ -201,7 +201,7 @@ Item {
         supportMaterialRequired = 0.0
         num_shells = ""
         extruder_temp = ""
-        buildplane_temp = ""
+        chamber_temp = ""
         slicer_name = ""
         startPrintWithUnknownMaterials = false
     }
@@ -639,9 +639,9 @@ Item {
                 }
 
                 InfoItem {
-                    id: printInfo_buildplaneTemperature
-                    labelText: qsTr("Buildplane Temperature")
-                    dataText: buildplane_temp
+                    id: printInfo_chamberTemperature
+                    labelText: qsTr("Chamber Temperature")
+                    dataText: chamber_temp
                 }
 
                 InfoItem {

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -263,7 +263,7 @@ Item {
                                      (qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp)) :
                                      "\n"))
                             } else {
-                                (qsTr("%1 C").arg(bot.buildplaneCurrentTemp) + " | " + qsTr("%1 C").arg(bot.buildplaneTargetTemp))
+                                (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -671,9 +671,9 @@ Item {
                         }
 
                         Text {
-                            id: buildplane_temp_label
+                            id: chamber_temp_label
                             color: "#cbcbcb"
-                            text: qsTr("BUILDPLANE TEMP")
+                            text: qsTr("chamber TEMP")
                             antialiasing: false
                             smooth: false
                             font.pixelSize: 18
@@ -740,9 +740,9 @@ Item {
                         }
 
                         Text {
-                            id: buildplane_temp_text
+                            id: chamber_temp_text
                             color: "#ffffff"
-                            text: qsTr("%1C").arg(bot.buildplaneCurrentTemp)
+                            text: qsTr("%1C").arg(bot.chamberCurrentTemp)
                             antialiasing: false
                             smooth: false
                             font.family: defaultFont.name


### PR DESCRIPTION
BW-5345
http://makerbot.atlassian.net/browse/BW-5345

Reverse buildplane temperature display changes of BW-5199 to allow other software teams to coordinate the adjustment of their temperature displays to time releases with each other.