### PR TITLE
Add support for browsing and printing files queued on cloudprint

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,8 @@ set(SOURCES
     settings_interface/settings_interface.cpp
     storage/disk_manager.cpp
     dfs/dfs_settings.cpp
-    print_queue/print_queue.cpp)
+    print_queue/print_queue.cpp
+    print_queue/asyncimageprovider.cpp)
 
 # These are not used QtCreator build
 set(MODEL_IMPL_SOURCES
@@ -86,7 +87,8 @@ set(MOREPORK_UI_HEADERS
     settings_interface/settings_interface.h
     storage/disk_manager.h
     dfs/dfs_settings.h
-    print_queue/print_queue.h)
+    print_queue/print_queue.h
+    print_queue/asyncimageprovider.h)
 
 if(NOT ${QT_CREATOR_BUILD})
     list(APPEND SOURCES ${MODEL_IMPL_SOURCES})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@ void msgHandler(QtMsgType type,
 #include "storage/disk_manager.h"
 #include "dfs/dfs_settings.h"
 #include "print_queue/print_queue.h"
+#include "print_queue/asyncimageprovider.h"
 
 int main(int argc, char ** argv) {
     qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard"));
@@ -94,8 +95,7 @@ int main(int argc, char ** argv) {
 
     qmlRegisterType<PrintFileInfo>("PrintFileObject", 1, 0, "PrintFileInfo");
     engine.addImageProvider(QLatin1String("thumbnail"), new ThumbnailPixmapProvider);
-    engine.addImageProvider(QLatin1String("print_queue"),
-                            new PrintQueueImageLoader(&print_queue));
+    engine.addImageProvider(QLatin1String("async"), new AsyncImageProvider);
 
     engine.load(MOREPORK_UI_QML_MAIN);
 

--- a/src/print_queue/asyncimageprovider.cpp
+++ b/src/print_queue/asyncimageprovider.cpp
@@ -1,0 +1,80 @@
+#include "asyncimageprovider.h"
+#include <QEventLoop>
+#include <QNetworkReply>
+#include <QNetworkAccessManager>
+
+AsyncImageProvider::AsyncImageProvider() {
+    pool_.setMaxThreadCount(16);
+}
+
+QQuickImageResponse* AsyncImageProvider::requestImageResponse(const QString &id,
+                                                const QSize &requestedSize) {
+    AsyncImageResponse *response = new AsyncImageResponse(id, requestedSize, &pool_);
+    return response;
+}
+
+AsyncImageResponse::AsyncImageResponse(const QString &id, const QSize &requestedSize,
+                                                                QThreadPool *pool) {
+    auto runnable = new AsyncImageResponseRunnable(id, requestedSize);
+    connect(runnable, &AsyncImageResponseRunnable::done, this, &AsyncImageResponse::handleDone);
+    pool->start(runnable);
+}
+
+AsyncImageResponseRunnable::AsyncImageResponseRunnable(const QString &id,
+                                                       const QSize &requestedSize)
+    : id_(id), requestedSize_(requestedSize) {}
+
+void AsyncImageResponseRunnable::run() {
+    QStringList list = id_.split("+");
+    QString urlPrefix = list[0];
+    QString jobId = list[1];
+    QString token = list[2];
+
+    QString thumbnail_name;
+    QString error_image;
+    switch(requestedSize_.width()) {
+    case ImageWidth::Small:
+        thumbnail_name = "thumbnail_140x106.png";
+        error_image = "file_no_preview_small.png";
+        break;
+    case ImageWidth::Medium:
+        thumbnail_name = "thumbnail_212x300.png";
+        error_image = "file_no_preview_medium.png";
+        break;
+    case ImageWidth::Large:
+        thumbnail_name = "thumbnail_960x1460.png";
+        error_image = "file_no_preview_medium.png";
+        break;
+    default:
+        thumbnail_name = "thumbnail_140x106.png";
+        error_image = "file_no_preview_medium.png";
+        break;
+    }
+    // To temporarily address cloudprint bug -
+    // https://makerbot.atlassian.net/browse/AB-1885
+    urlPrefix = "https://cloudprint.mbot.me/api/queue/jobs/";
+
+    QNetworkReply *reply = nullptr;
+    QNetworkRequest request(QUrl(urlPrefix + jobId + "/info/" + thumbnail_name));
+    request.setRawHeader(QByteArray("Authorization"),
+                         QByteArray(QString("Bearer " + token).toUtf8()));
+
+    QNetworkAccessManager n;
+    reply = n.get(request);
+
+    QObject::connect(&n, &QNetworkAccessManager::sslErrors,
+            reply, [=]{reply->ignoreSslErrors();});
+
+    QEventLoop loop;
+    QObject::connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
+    loop.exec();
+
+    QImage image;
+    if(reply->error() != QNetworkReply::NoError) {
+        image = QImage(":/img/" + error_image);
+    } else {
+        image = QImage::fromData(reply->readAll());
+    }
+    reply->deleteLater();
+    emit done(image);
+}

--- a/src/print_queue/asyncimageprovider.h
+++ b/src/print_queue/asyncimageprovider.h
@@ -1,0 +1,56 @@
+#ifndef ASYNCIMAGEPROVIDER_H
+#define ASYNCIMAGEPROVIDER_H
+#include <QQuickAsyncImageProvider>
+#include <QImage>
+#include <QThreadPool>
+
+class QNetworkReply;
+
+class AsyncImageProvider : public QQuickAsyncImageProvider {
+public:
+    explicit AsyncImageProvider();
+    QQuickImageResponse* requestImageResponse(const QString &id, const QSize &requestedSize) override;
+
+private:
+    QThreadPool pool_;
+};
+
+class AsyncImageResponse : public QQuickImageResponse {
+public:
+    explicit AsyncImageResponse(const QString &id, const QSize &requestedSize,
+                       QThreadPool *pool);
+
+    void handleDone(QImage image) {
+        image_ = image;
+        emit finished();
+    }
+
+    QQuickTextureFactory *textureFactory() const override {
+        return QQuickTextureFactory::textureFactoryForImage(image_);
+    }
+
+    QImage image_;
+};
+
+class AsyncImageResponseRunnable : public QObject, public QRunnable {
+    Q_OBJECT
+public:
+    explicit AsyncImageResponseRunnable(const QString &id, const QSize &requestedSize);
+
+    void run() override;
+
+    enum ImageWidth {
+        Small = 140,
+        Medium = 212,
+        Large = 960
+    };
+
+signals:
+    void done(QImage image);
+
+private:
+    QString id_;
+    QSize requestedSize_;
+};
+
+#endif // ASYNCIMAGEPROVIDER_H

--- a/src/print_queue/print_queue.h
+++ b/src/print_queue/print_queue.h
@@ -24,6 +24,9 @@ public:
     Q_INVOKABLE void startQueuedPrint(QString urlPrefix, QString jobId, QString token);
     void cleanup();
 
+    Q_INVOKABLE void asyncFetchMeta(QString urlPrefix, QString jobId, QString token, const QJSValue &callback);
+    QVariant fetchMeta(QString urlPrefix, QString jobId, QString token);
+
 signals:
     void FetchMetadataSuccessful(QVariant meta);
     void FetchMetadataFailed();
@@ -38,27 +41,6 @@ public:
 private:
     QNetworkReply *metaReply_;
     QUrl cancelledRequest_;
-};
-
-class PrintQueueImageLoader : public QQuickImageProvider {
-  public:
-    PrintQueueImageLoader(PrintQueue *pqueue)
-        : QQuickImageProvider(QQuickImageProvider::Pixmap),
-          printQueue_(pqueue),
-          imageReply_(nullptr) {}
-
-    enum ImageWidth {
-        Small = 140,
-        Medium = 212,
-        Large = 960
-    };
-
-    QPixmap requestPixmap(const QString &jobId, QSize *size,
-                          const QSize &requestedSize);
-
-private:
-  PrintQueue *printQueue_;
-  QNetworkReply *imageReply_;
 };
 
 #endif // PRINTQUEUE_H

--- a/src/qml/FileButtonForm.qml
+++ b/src/qml/FileButtonForm.qml
@@ -18,6 +18,9 @@ Button {
     property alias materialError: materialErrorAlertIcon
     property color buttonColor: "#00000000"
     property color buttonPressColor: "#0f0f0f"
+    property var metaData
+    property bool hasMeta: false
+    property  bool metaCached: false
 
     background:
         Rectangle {
@@ -36,17 +39,16 @@ Button {
         smooth: false
     }
 
-    Image {
+    ImageWithFeedback {
         id: fileThumbnail
-        sourceSize.width: 140
-        sourceSize.height: 106
-        asynchronous: true
-        smooth: false
+        width: 140
+        height: 106
         antialiasing: false
         fillMode: Image.PreserveAspectFit
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         anchors.leftMargin: 25
+        loadingSpinnerSize: 32
     }
 
     Item {

--- a/src/qml/ImageWithFeedback.qml
+++ b/src/qml/ImageWithFeedback.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.4
+
+ImageWithFeedbackForm {
+}

--- a/src/qml/ImageWithFeedbackForm.qml
+++ b/src/qml/ImageWithFeedbackForm.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.12
+
+Image {
+    id: image_with_feedback
+    property alias loadingSpinnerSize: spinner.spinnerSize
+
+    asynchronous: true
+    smooth: false
+    sourceSize.width: width
+    sourceSize.height: height
+    source: {
+        if(startPrintSource == PrintPage.FromPrintQueue) {
+            "image://async/" + print_url_prefix + "+" +
+                                     print_job_id + "+" +
+                                     print_token
+        } else if(startPrintSource == PrintPage.FromLocal) {
+            "image://thumbnail/" + fileName
+        } else {
+            ""
+        }
+    }
+
+    BusySpinner {
+        id: spinner
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        spinnerSize: 64
+        spinnerActive: image_with_feedback.status == Image.Loading
+    }
+}

--- a/src/qml/StartPrintPageForm.qml
+++ b/src/qml/StartPrintPageForm.qml
@@ -32,23 +32,15 @@ Item {
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 20
 
-            Image {
+            ImageWithFeedback {
                 id: model_image1
-                smooth: false
-                sourceSize.width: 212
-                sourceSize.height: 300
+                width: 212
+                height: 300
                 anchors.left: parent.left
                 anchors.leftMargin: 100
+                asynchronous: true
                 anchors.verticalCenter: parent.verticalCenter
-                source: {
-                    if(browsingPrintQueue) {
-                        "image://print_queue/" + print_url_prefix + "+" +
-                                                 print_job_id + "+" +
-                                                 print_token
-                    } else {
-                        "image://thumbnail/" + fileName
-                    }
-                }
+                loadingSpinnerSize: 48
             }
 
             Item {
@@ -181,14 +173,14 @@ Item {
                     buttonHeight: 50
                     label: inFreStep ? qsTr("START TEST PRINT") : qsTr("START PRINT")
                     button_mouseArea.onClicked: {
-                        if(!browsingPrintQueue) {
+                        if(startPrintSource == PrintPage.FromLocal) {
                             if(startPrintCheck()){
                                 startPrint()
                             }
                             else {
                                 startPrintErrorsPopup.open()
                             }
-                        } else {
+                        } else if(startPrintSource == PrintPage.FromPrintQueue) {
                             print_queue.startQueuedPrint(print_url_prefix,
                                                          print_job_id,
                                                          print_token)
@@ -204,7 +196,7 @@ Item {
                     label: "···"
                     label_size: 30
                     visible: !inFreStep
-                    disable_button: browsingPrintQueue
+                    disable_button: startPrintSource == PrintPage.FromPrintQueue
                     anchors.top: materialBay2.bottom
                     anchors.topMargin: 28
                     anchors.left: startPrintButton.right
@@ -232,23 +224,15 @@ Item {
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 20
 
-            Image {
+            ImageWithFeedback {
                 id: model_image2
-                smooth: false
-                sourceSize.width: 212
-                sourceSize.height: 300
+                width: 212
+                height: 300
+                asynchronous: true
                 anchors.left: parent.left
                 anchors.leftMargin: 100
                 anchors.verticalCenter: parent.verticalCenter
-                source: {
-                    if(browsingPrintQueue) {
-                        "image://print_queue/" + print_url_prefix + "+" +
-                                                 print_job_id + "+" +
-                                                 print_token
-                    } else {
-                        "image://thumbnail/" + fileName
-                    }
-                }
+                loadingSpinnerSize: 48
             }
 
             ColumnLayout {
@@ -520,19 +504,16 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
                         color: "transparent"
-                        Image {
-                            anchors.fill: parent
+
+                        ImageWithFeedback {
+                            id: largeThumbnail
+                            mipmap: true
                             sourceSize.width: 960
                             sourceSize.height: 1460
-                            source: {
-                                if(browsingPrintQueue) {
-                                    "image://print_queue/" + print_url_prefix + "+" +
-                                                             print_job_id + "+" +
-                                                             print_token
-                                } else {
-                                    "image://thumbnail/" + fileName
-                                }
-                            }
+                            anchors.fill: parent
+                            asynchronous: true
+                            loadingSpinnerSize: 48
+
                             MouseArea {
                                 anchors.fill: parent
                                 onDoubleClicked: {

--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -190,6 +190,7 @@ Item {
                         switch(printPage.printSwipeView.currentIndex) {
                         case PrintPage.BasePage:
                         case PrintPage.FileBrowser:
+                        case PrintPage.PrintQueueBrowser:
                             qsTr("CHOOSE A FILE")
                             break;
                         case PrintPage.StartPrintConfirm:

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -220,5 +220,7 @@
         <file>FilterStatusPageForm.qml</file>
         <file>ReplaceFilterPage.qml</file>
         <file>ReplaceFilterPageForm.qml</file>
+        <file>ImageWithFeedback.qml</file>
+        <file>ImageWithFeedbackForm.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This commit allows browsing the print queue with just the print filenames listed. After clicking
a print, a network request is made to download the meta.json. The start print page is shown
after the meta file and the images in the start print page are also downloaded. After starting
a print (asking teams to start a print) the UI also visually informs the user and checks that the
print actually starts within the next 30 seconds.

BW-5335
https://makerbot.atlassian.net/browse/BW-5335