### PR TITLE
Fix: Drying Feature Clear Build Plate Warning Appears Twice

### DIFF
--- a/src/qml/DryMaterialForm.qml
+++ b/src/qml/DryMaterialForm.qml
@@ -28,6 +28,7 @@ Item {
                     break;
                 case ProcessStateType.Loading:
                 case ProcessStateType.DryingSpool:
+                    doChooseMaterial = false
                     state = "drying_spool"
                     break;
                 case ProcessStateType.Done:

--- a/src/qml/DryMaterialSelectorForm.qml
+++ b/src/qml/DryMaterialSelectorForm.qml
@@ -33,7 +33,6 @@ ListView {
         antialiasing: false
         onClicked: {
             bot.startDrying(parseInt(model.modelData["temperature"], 10), model.modelData["time"])
-            doChooseMaterial = false
         }
     }
 }


### PR DESCRIPTION
Turns out that the clear buildplate popup was appearing every time the action
button was clicked. We want the popup to appear only before starting the
drying process. Added some logic and moved things around to have the proper
flow.
BW-5441
http://makerbot.atlassian.net/browse/BW-5441