### PR TITLE
Use lightweight loading indicator for thumbnail images

### DIFF
--- a/src/qml/FileButtonForm.qml
+++ b/src/qml/FileButtonForm.qml
@@ -39,7 +39,7 @@ Button {
         smooth: false
     }
 
-    ImageWithFeedback {
+    ThumbnailImage {
         id: fileThumbnail
         width: 140
         height: 106
@@ -48,7 +48,6 @@ Button {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         anchors.leftMargin: 25
-        loadingSpinnerSize: 32
     }
 
     Item {

--- a/src/qml/ThumbnailImage.qml
+++ b/src/qml/ThumbnailImage.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.4
+
+ThumbnailImageForm {
+}

--- a/src/qml/ThumbnailImageForm.qml
+++ b/src/qml/ThumbnailImageForm.qml
@@ -1,0 +1,31 @@
+import QtQuick 2.12
+
+Image {
+    id: thumbnail_image
+    asynchronous: true
+    smooth: false
+    sourceSize.width: width
+    sourceSize.height: height
+    source: {
+        if(startPrintSource == PrintPage.FromPrintQueue) {
+            "image://async/" + print_url_prefix + "+" +
+                                     print_job_id + "+" +
+                                     print_token
+        } else if(startPrintSource == PrintPage.FromLocal) {
+            "image://thumbnail/" + fileName
+        } else {
+            ""
+        }
+    }
+
+    Rectangle {
+        height: 72
+        width: 72
+        color: "#1c1c1c"
+        radius: 36
+        border.width: 0
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        visible: thumbnail_image.status == Image.Loading
+    }
+}

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -222,5 +222,7 @@
         <file>ReplaceFilterPageForm.qml</file>
         <file>ImageWithFeedback.qml</file>
         <file>ImageWithFeedbackForm.qml</file>
+        <file>ThumbnailImage.qml</file>
+        <file>ThumbnailImageForm.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
The loading indicator for all images in the cloud queue list was the busy
spinner used thrughout the UI. Since it's an animated element and is
rendered multiple times, one for each prints small thumbnail it had a
significant impact on the scrolling performance of the list. This commit
replaces the loading indicator with a lightweight placeholder circle as
per the design teams request.