### PR TITLE
Fix for empty print queues in the bot model

### DIFF
--- a/src/model_impl/kaiten_net_model.cpp
+++ b/src/model_impl/kaiten_net_model.cpp
@@ -110,7 +110,7 @@ void KaitenNetModel::cloudServicesInfoUpdate(const Json::Value &result) {
 }
 
 void KaitenNetModel::printQueueUpdate(const Json::Value &queue) {
-    if (queue.isArray() && queue.size() > 0) {
+    if (queue.isArray()) {
         QList<QObject*> print_queue_list;
         print_queue_list.clear();
 


### PR DESCRIPTION
BW-5503
https://makerbot.atlassian.net/browse/BW-5503

We do need to update the bot model print queue to be an empty list when kaiten sends us a notification that the print queue is empty.   I don't know if the intention here was to handle the empty list case in a separate else clause that was never added, but all of the code here should correctly handle an empty queue already...