### PR TITLE
Materials not verified when print queued from CloudPrint

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -225,7 +225,7 @@ Item {
             "PVA-M"
             break;
         case 8:
-            "SR30"
+            "SR-30"
             break;
         case 9:
             "ASA"
@@ -324,7 +324,7 @@ Item {
                 ["PVA"]
                 break;
             case ExtruderType.MK14_HOT:
-                ["SR30", "HIPS", "RapidRinse"]
+                ["SR-30", "HIPS", "RapidRinse"]
                 break;
             default:
                 []

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -208,8 +208,8 @@ Item {
         var printTimeSec = meta['duration_s']
         model_extruder_used = meta['extrusion_distances_mm'][0] > 0 ? true : false
         support_extruder_used = meta['extrusion_distances_mm'][1] > 0 ? true : false
-        print_model_material = meta['materials'][0]
-        print_support_material = meta['materials'][1]
+        print_model_material = storage.updateMaterialNames(meta['materials'][0])
+        print_support_material = storage.updateMaterialNames(meta['materials'][1])
         print_material = !support_extruder_used ?
                             meta['materials'][0] :
                             meta['materials'][0] + "+" + meta['materials'][1]

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -256,10 +256,10 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
     MakerbotFileMetaReader file_meta_reader(kFileInfo);
     if(file_meta_reader.loadMetadata()) {
         auto &meta_data = file_meta_reader.meta_data_;
-        QString material_name_a = QString::fromStdString(meta_data->material[0]);
-        updateMaterialNames(material_name_a);
-        QString material_name_b = QString::fromStdString(meta_data->material[1]);
-        updateMaterialNames(material_name_b);
+        QString material_name_a = updateMaterialNames(
+                QString::fromStdString(meta_data->material[0]));
+        QString material_name_b = updateMaterialNames(
+                QString::fromStdString(meta_data->material[1]));
         return
             // e.g. "/tmp/archive.tar.gz"
             new PrintFileInfo(
@@ -475,7 +475,7 @@ void MoreporkStorage::backStackClear(){
   back_dir_stack_.clear();
 }
 
-void MoreporkStorage::updateMaterialNames(QString &name) {
+QString MoreporkStorage::updateMaterialNames(QString name) {
     if(name == "im-pla") {
         name = "tough";
     } else if(name == "pet") {
@@ -493,4 +493,5 @@ void MoreporkStorage::updateMaterialNames(QString &name) {
     } else if(name == "generic_model") {
         name = "unknown";
     }
+    return name;
 }

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -347,7 +347,7 @@ class MoreporkStorage : public QObject {
     // throughout fw/toolpath) to user facing (marketing) names
     // displayed on the printer UI. All comparisons on UI happen
     // with marketing names for simplicity.
-    void updateMaterialNames(QString &material);
+    Q_INVOKABLE QString updateMaterialNames(QString material);
 
     Q_INVOKABLE void getTestPrint(const QString test_print_dir,
                                   const QString test_print_name);


### PR DESCRIPTION
- Use the same material check popup as we do for printing from USB.
- There was a bug with the SR30 material name. It was written as SR-30
  in the UI firmware which caused a mismatch when checking against SR30 (without hyphen).
BW-5508
http://makerbot.atlassian.net/browse/BW-5508