### PR TITLE
always forward net model copy of queue to UI

### DIFF
--- a/src/model_impl/kaiten_net_model.cpp
+++ b/src/model_impl/kaiten_net_model.cpp
@@ -127,10 +127,9 @@ void KaitenNetModel::printQueueUpdate(const Json::Value &queue) {
 
         if (print_queue_list.empty()) {
             printQueueEmptyReset();
-            PrintQueueReset();
         } else {
             printQueueEmptySet(false);
-            PrintQueueSet(print_queue_list);
         }
+        PrintQueueSet(print_queue_list);
     }
 }


### PR DESCRIPTION
BW-5518
http://makerbot.atlassian.net/browse/BW-5518

For some reason, the generated function:
`    PrintQueueReset();`
is not equivalent to the sequence:
```
    print_queue_list.empty();

    ...

    PrintQueueSet(print_queue_list);
```

when the cloudprint queue is empty, whether upon printer startup, or
after the last remaining entry in the queue is removed (via
cancellation, deletion, or completed print).