### PR TITLE
Disable swiping up and down for drawers

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -227,7 +227,10 @@ ApplicationWindow {
         if(activeDrawer == printPage.printingDrawer ||
            activeDrawer == materialPage.materialPageDrawer ||
            activeDrawer == printPage.sortingDrawer) {
-            activeDrawer.interactive = state
+            // Patch to disable swiping of the drawer, which appears
+            // to eliminate glitchy back button issues that present
+            // themselves on some units.
+            // activeDrawer.interactive = state
             if(state) {
                 topBar.drawerDownClicked.connect(activeDrawer.open)
             }


### PR DESCRIPTION
This disables the "interactive" property for all top drawer widgets, which means that they cannot be swiped down or up.  All drawers can still be accessed by tapping the title bar and all drawers contain an option to dismiss the drawer, so no actions are blocked by this.  But on some printers produced more recently, whenever we are on a screen with a drawer enabled, the back button appears to only function correctly a small fraction of the time that it is pressed (this has been tested most extensively with tapping the back button, but tapping the title bar and swiping from the far left edge to go back appear equally affected).  Testing on these printers indicates that it is specifically the action of setting the drawer to interactive that produces these symptoms.

My best guess would be that internally, Qt is creating some sort of mouse area for the drawer that overlaps the top bar and has priority over our explicitly created mouse areas, so that the internal drawer logic has control over whether touch events get forwarded to the mouse areas below.  Presumably this logic is intended to forward all events that are not detected as downward swipes.  If there are race conditions in this logic, that could explain part of what we are seeing here...