### PR TITLE
Disable the back swipe drawer to reclaim touch area on the back button

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -365,7 +365,7 @@ ApplicationWindow {
             edge: rootItem.rotation == 180 ? Qt.RightEdge : Qt.LeftEdge
             dim: false
             opacity: 0
-            interactive: mainSwipeView.currentIndex
+            interactive: false
             onOpened: {
                 position = 0
                 goBack()


### PR DESCRIPTION
The swipe from left to go back feature is implemented using a drawer. There
is a bug in Qt (https://bugreports.qt.io/browse/QTBUG-59141) that prevents
touches on the drawer's dragMargin area from propagating to components below
it, in this case some portion of the back button.

BW-5529
https://makerbot.atlassian.net/browse/BW-5529