### PR TITLE
RFAdvice: coercion issue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
     model/logger.cpp
     model/network.cpp
     model/fre_tracker.cpp
+    model/ui_event_logger.cpp
     storage/storage.cpp
     settings_interface/settings_interface.cpp
     storage/disk_manager.cpp
@@ -82,6 +83,7 @@ set(MOREPORK_UI_HEADERS
     model/process_model.h
     model/network.h
     model/fre_tracker.h
+    model/ui_event_logger.h
     storage/storage.h
     storage/progress_copy.h
     settings_interface/settings_interface.h

--- a/src/host/host_main.qml
+++ b/src/host/host_main.qml
@@ -14,6 +14,8 @@ QtObject {
         Model {
             anchors.fill: parent
         }
+
+       Component.onCompleted: UiEventLogger.beginUiLogging(Window)
     }
 
     property var uiWindow: Ui.MoreporkUI {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "logger.h"
 #include "logging.h"
 #include "network.h"
+#include "model/ui_event_logger.h"
 
 // TODO: We should probably be able to set this up so that
 //       the qrc thing works for all builds...
@@ -69,6 +70,7 @@ int main(int argc, char ** argv) {
     SettingsInterface settings;
     DiskManager disk_manager;
     DFSSettings dfs_settings;
+    QObject events_log = dynamic_cast<QObject>(UiEventLogger::GetInstance);
 
     QLocale::setDefault(QLocale(settings.getLanguageCode()));
 
@@ -99,6 +101,10 @@ int main(int argc, char ** argv) {
     engine.addImageProvider(QLatin1String("async"), new AsyncImageProvider);
 
     engine.load(MOREPORK_UI_QML_MAIN);
+
+    engine.rootContext()->setContextProperty("events_log", (QObject*)&events_log);
+    qmlRegisterSingletonType<UiEventLogger>("events_log", 1, 0, "UiEventLogger",
+        UiEventLogger::GetInstance);
 
     QObject *rootObject = engine.rootObjects().first();
     QObject *qmlObject = rootObject->findChild<QObject*>("morepork_main_qml");

--- a/src/model/ui_event_logger.cpp
+++ b/src/model/ui_event_logger.cpp
@@ -1,0 +1,47 @@
+#include "ui_event_logger.h"
+#include <QObject>
+#include <QtGui>
+#include <QtQml>
+
+QObject *UiEventLogger::GetInstance(QQmlEngine* engine, QJSEngine* sengine) {
+    // Q_UNUSED(engine)
+    // Q_UNUSED(sengine)
+
+    static UiEventLogger instance;
+    return &instance;
+}
+
+void UiEventLogger::beginUiEventLogging(QObject *obj) {
+    if (!obj)
+        return;
+    obj->installEventFilter(this);
+    qInfo() << "UIEVENTLOGGER begin for [" << obj << "]";
+}
+
+bool UiEventLogger::eventFilter(QObject *obj, QEvent *event) {
+    // todo(william): make this toggleable to avoid spamming the logs
+    if(1) {
+        qInfo() << "UIEVENTLOGGER";
+        switch(event->type()) {
+            case QEvent::MouseButtonPress: {
+                QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+                qInfo() << "Mouse Press Event: [" << obj << "] got [" <<
+                    mouseEvent->globalX() << "," <<
+                    mouseEvent->globalY() << "]";
+                break;
+            }
+            default: {
+                qInfo() << "Unknown event type: [" << obj << "] got [" <<
+                    event->type() << "]";
+            }
+        }
+    }
+
+    /* always return false to ensure the appropriate underlying UI
+     * entity eventually recieves UI events
+     */
+    return false;
+}
+
+// UiEventLogger::UiEventLogger(QObject *parent = nullptr) : QObject(parent) {}
+UiEventLogger::UiEventLogger() {}

--- a/src/model/ui_event_logger.h
+++ b/src/model/ui_event_logger.h
@@ -1,0 +1,27 @@
+#ifndef UI_EVENT_LOGGING_H
+#define UI_EVENT_LOGGING_H
+
+#include "logging.h"
+#include <QObject>
+#include <QtGui>
+#include <QtQml>
+
+class UiEventLogger : public QObject
+{
+    Q_OBJECT
+
+public:
+    static QObject *GetInstance(QQmlEngine* engine, QJSEngine* sengine);
+
+    Q_INVOKABLE void beginUiEventLogging(QObject *object);
+    bool eventFilter(QObject *obj, QEvent *event);
+
+    UiEventLogger(UiEventLogger const&) = delete;
+    void operator=(UiEventLogger const&) = delete;
+
+private:
+    UiEventLogger();
+};
+
+#endif
+


### PR DESCRIPTION
BW-5492
http://makerbot.atlassian.net/browse/BW-5492

Took in advice from multiple online sources re: how to attach Qt EventFilters to QML, primarily from:

    https://stackoverflow.com/questions/38698604/how-to-install-and-use-an-event-filter-written-in-qt-c-in-a-qml-application

As well as singleton implementation guidelines from:

    https://stackoverflow.com/questions/1008019/c-singleton-design-pattern

Currently, the singleton GetInstance prototype is written to be compatible with the main.cpp::qmlRegisterSingletonType() call's required parameters, but runs afoul of the instantiation as a "plain" QObject:
    error: cannot dynamic_cast 'UiEventLogger::GetInstance' (of type 'class QObject* (*)(class QQmlEngine*, class QJSEngine*)') to type 'class QObject' (target is not pointer or reference)