### PR TITLE
add indicator for language-change-in-progress

### DIFF
--- a/src/qml/LanguageButtonForm.qml
+++ b/src/qml/LanguageButtonForm.qml
@@ -7,20 +7,26 @@ Button {
     width: parent.width
     height: 80
     smooth: false
+    enabled: !(currentLocale == localeCode)
 
     onClicked: {
-        translate.selectLanguage(localeCode)
-        settings.setLanguageCode(localeCode)
+        console.log("[=" + languageName + "=] clicked")
+        itemSelectLanguage.loadingIcon.visible = true
+        delay(500, function() {
+            translate.selectLanguage(localeCode);
+            settings.setLanguageCode(localeCode);
 
-        // currentLocale is referenced from the parent page
-        // 'LanguageSelectorForm.qml' which is a bad thing
-        // to do in qml as the refernece will be silently
-        // lost when this child is reused elesewhere and
-        // only fail at runtime.
+            // currentLocale is referenced from the parent page
+            // 'LanguageSelectorForm.qml' which is a bad thing
+            // to do in qml as the refernece will be silently
+            // lost when this child is reused elesewhere and
+            // only fail at runtime.
 
-        // The locale name can only be accessed from
-        // the constructed object
-        currentLocale = Qt.locale().name
+            // The locale name can only be accessed from
+            // the constructed object
+            currentLocale = Qt.locale().name;
+            itemSelectLanguage.loadingIcon.visible = false;
+        })
     }
 
     property alias isSelected: isSelectedImage.visible
@@ -28,6 +34,17 @@ Button {
     property string localeCode: "en_GB"
     property color buttonColor: "#00000000"
     property color buttonPressColor: "#0f0f0f"
+
+    Timer {
+        id: timer
+    }
+
+    function delay(delayTime, cb) {
+        timer.interval = 1000
+        timer.repeat = false
+        timer.triggered.connect(cb)
+        timer.start()
+    }
 
     background:
         Rectangle {

--- a/src/qml/LanguageSelectorForm.qml
+++ b/src/qml/LanguageSelectorForm.qml
@@ -9,6 +9,7 @@ Item {
     anchors.fill: parent
 
     property string currentLocale
+    property alias loadingIcon: loadingIcon
 
     Flickable {
         id: flickableSelectLanguage
@@ -86,5 +87,14 @@ Item {
                 localeCode: "es_ES"
             }
         }
+    }
+
+    LoadingIcon {
+        id: loadingIcon
+        anchors.verticalCenterOffset: -30
+        anchors.left: parent.left
+        anchors.leftMargin: 260
+        anchors.verticalCenter: parent.verticalCenter
+        visible: false
     }
 }


### PR DESCRIPTION
BW-4934
http://makerbot.atlassian.net/browse/BW-4934

Edit: Oops, this patch is addressing ticket BW-4934, I mis-read the ticket number when creating the branch name.

Preliminary work on an indicator that "a language change is in progress". I reused the current animated "loading" icon, and
named this patch "preliminary" in case this is visually undesireable. A timer was used to give time for the UI to initialize the QT animation before the language-change consumed all UI resources.

I also added a language-choice-button disabler when that language is currently selected, to prevent needless waiting for the
same language to be loaded again.

In fact, all buttons ought to be disabled once a language change has been initiated, and re-enabled afterwards, but that may
already have been recorded as a ticket elsewhere.