### PR TITLE
Create two versions of the UI application

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,7 @@ if(NOT ${QT_CREATOR_BUILD})
         Boost::chrono
         pthread
       )
+    target_compile_options(morepork_ui PRIVATE -g)
 else()
     if(${HAVE_LIBTINYTHING})
         target_link_libraries(morepork_ui JsonCpp::jsoncpp TinyThing::tinything)
@@ -174,7 +175,33 @@ if(NOT ${QT_CREATOR_BUILD})
     set_target_properties(morepork_ui PROPERTIES
         LINK_FLAGS "-Wl,-rpath-link=${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
 
-    install(TARGETS morepork_ui DESTINATION ${BIN_INSTALL_DIR})
+    # We compiled morepork_ui with debug symbols, but we only want to install
+    # with debug symbols to staging.  The binary is also huge because of all
+    # of the images/animations bundled into it, so we strip the rodata section
+    # that contains all of these from staging and hope it doesn't affect debug.
+    set(strip_path "${CMAKE_BINARY_DIR}/morepork_ui.strip")
+    set(debug_path "${CMAKE_BINARY_DIR}/morepork_ui.debug")
+    add_custom_command(TARGET morepork_ui POST_BUILD
+        COMMAND ${CMAKE_STRIP} --strip-unneeded -o "${strip_path}"
+            "$<TARGET_FILE:morepork_ui>"
+        COMMAND ${CMAKE_OBJCOPY} -R .rodata
+            "$<TARGET_FILE:morepork_ui>" "${debug_path}")
+    install(
+        FILES "${strip_path}"
+        DESTINATION "${BIN_INSTALL_DIR}"
+        RENAME morepork_ui
+        PERMISSIONS
+            OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            GROUP_EXECUTE GROUP_READ
+            WORLD_EXECUTE WORLD_READ)
+    install(
+        FILES "${debug_path}"
+        DESTINATION "${STAGING_BIN_INSTALL_DIR}"
+        RENAME morepork_ui
+        PERMISSIONS
+            OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            GROUP_EXECUTE GROUP_READ
+            WORLD_EXECUTE WORLD_READ)
 
     install(DIRECTORY "${MoreporkUI_SOURCE_DIR}/fonts" DESTINATION
         "${ROOT_INSTALL_DIR}/usr/lib")


### PR DESCRIPTION
We are now adding debug symbols to everything that we compile, even with
all other debugging disabled.  We don't want to put debug symbols into
the copy of the application that actually ends up in the firmware, so we
make a stripped copy of the application to install there.  We also want
an application copy with debug symbols to be installed to staging.
However, the size of both the executable and debug sections of the
application are absolutely dwarfed by the bundled resources, and putting
two copies of these resources into every artifact we build is a bit much.
So we strip out the section that contains the bundled resources from the
debugging copy.

Note that stripping the bundled resources does seem to leave allocated
space for the resources in the file but leaves the contents zeroed out,
so space is only saved when compressing the file into an artifact.  We
could probably find a way to shrink the uncompressed binary as well but
the artifact size is what really matters here.