### PR TITLE
swap chamber and temps w/ buildplane equivalents

### DIFF
--- a/src/qml/AdvancedInfoChamberItemForm.qml
+++ b/src/qml/AdvancedInfoChamberItemForm.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.3
 
 Item {
     width: 400
-    height: 240
+    height: 300
 
     ColumnLayout {
         id: columnLayout
@@ -31,14 +31,26 @@ Item {
 
         AdvancedInfoElement {
             id: currentTempProperty
-            label: qsTr("CURRENT TEMP.")
+            label: qsTr("CHAMBER TEMP.")
             value: bot.infoChamberCurrentTemp
         }
 
         AdvancedInfoElement {
             id: targetTempProperty
-            label: qsTr("TARGET TEMP.")
+            label: qsTr("CHAMBER TARGET")
             value: bot.infoChamberTargetTemp
+        }
+
+        AdvancedInfoElement {
+            id: buildplaneTempProperty
+            label: qsTr("BUILDPLANE TEMP.")
+            value: bot.buildplaneCurrentTemp
+        }
+
+        AdvancedInfoElement {
+            id: buildplaneTargetProperty
+            label: qsTr("BUILDPLANE TARGET")
+            value: bot.buildplaneTargetTemp
         }
 
         AdvancedInfoElement {

--- a/src/qml/AnnealPrintForm.qml
+++ b/src/qml/AnnealPrintForm.qml
@@ -156,7 +156,7 @@ Item {
             }
 
             Text {
-                id: chamber_temperature_text
+                id: buildplane_temperature_text
                 text: "999"
                 font.family: defaultFont.name
                 color: "#ffffff"
@@ -276,8 +276,8 @@ Item {
             }
 
             PropertyChanges {
-                target: chamber_temperature_text
-                text: bot.chamberCurrentTemp + "°C"
+                target: buildplane_temperature_text
+                text: bot.buildplaneCurrentTemp + "°C"
             }
 
             PropertyChanges {

--- a/src/qml/DryMaterialForm.qml
+++ b/src/qml/DryMaterialForm.qml
@@ -211,7 +211,7 @@ Item {
             }
 
             Text {
-                id: chamber_temperature_text
+                id: buildplane_temperature_text
                 text: "999"
                 font.family: defaultFont.name
                 color: "#ffffff"
@@ -439,8 +439,8 @@ Item {
             }
 
             PropertyChanges {
-                target: chamber_temperature_text
-                text: bot.chamberCurrentTemp + "°C" + " | " + bot.chamberTargetTemp + "°C"
+                target: buildplane_temperature_text
+                text: bot.buildplaneCurrentTemp + "°C" + " | " + bot.buildplaneTargetTemp + "°C"
             }
 
             PropertyChanges {

--- a/src/qml/PreheatPageForm.qml
+++ b/src/qml/PreheatPageForm.qml
@@ -26,18 +26,18 @@ Item {
             MenuButton {
                 id: buttonStartStopPreheat
                 buttonImage.source: "qrc:/img/icon_preheat.png"
-                buttonText.text: bot.chamberTargetTemp > 0 ?
+                buttonText.text: bot.buildplaneTargetTemp > 0 ?
                                      qsTr("STOP CHAMBER PREHEAT") :
                                      qsTr("START CHAMBER PREHEAT")
                 Text {
                     id: temperature_text
                     color: "#ffffff"
                     text: {
-                        if(bot.chamberTargetTemp > 0) {
-                            bot.chamberCurrentTemp + "|" + bot.chamberTargetTemp + qsTr("\u00b0C")
+                        if(bot.buildplaneTargetTemp > 0) {
+                            bot.buildplaneCurrentTemp + "|" + bot.buildplaneTargetTemp + qsTr("\u00b0C")
                         }
                         else {
-                            bot.chamberCurrentTemp + qsTr("\u00b0C")
+                            bot.buildplaneCurrentTemp + qsTr("\u00b0C")
                         }
                     }
                     font.letterSpacing: 3
@@ -46,7 +46,7 @@ Item {
                     font.pixelSize: 20
                     anchors.right: parent.right
                     anchors.rightMargin: {
-                        if(bot.chamberTargetTemp > 0) {
+                        if(bot.buildplaneTargetTemp > 0) {
                             35
                         }
                         else {

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -203,7 +203,7 @@ Item {
                             } else if(bot.extruderATargetTemp > 0) {
                                 qsTr("HEATING UP EXTRUDER")
                             } else {
-                                qsTr("HEATING UP CHAMBER")
+                                qsTr("HEATING UP BUILDPLANE")
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -257,7 +257,7 @@ Item {
                                      (qsTr("\n%1 C").arg(bot.extruderBCurrentTemp) + " | " + qsTr("%1 C").arg(bot.extruderBTargetTemp)) :
                                      "\n"))
                             } else {
-                                (qsTr("%1 C").arg(bot.chamberCurrentTemp) + " | " + qsTr("%1 C").arg(bot.chamberTargetTemp))
+                                (qsTr("%1 C").arg(bot.buildplaneCurrentTemp) + " | " + qsTr("%1 C").arg(bot.buildplaneTargetTemp))
                             }
                             break;
                         case ProcessStateType.Printing:
@@ -646,9 +646,9 @@ Item {
                         }
 
                         Text {
-                            id: chamber_temp_label
+                            id: buildplane_temp_label
                             color: "#cbcbcb"
-                            text: qsTr("CHAMBER TEMP")
+                            text: qsTr("BUILDPLANE TEMP")
                             antialiasing: false
                             smooth: false
                             font.pixelSize: 18
@@ -729,9 +729,9 @@ Item {
                         }
 
                         Text {
-                            id: chamber_temp_text
+                            id: buildplane_temp_text
                             color: "#ffffff"
-                            text: qsTr("%1C").arg(bot.chamberCurrentTemp)
+                            text: qsTr("%1C").arg(bot.buildplaneCurrentTemp)
                             antialiasing: false
                             smooth: false
                             font.family: defaultFont.name

--- a/src/qml/WaitToCoolChamberScreenForm.qml
+++ b/src/qml/WaitToCoolChamberScreenForm.qml
@@ -104,7 +104,7 @@ Item {
         Text {
             id: description_text
             color: "#cbcbcb"
-            text: qsTr("The build chamber temperature is<br>at <b>%1 C.</b>").arg(bot.chamberCurrentTemp) +
+            text: qsTr("The build plane temperature is<br>at <b>%1 C.</b>").arg(bot.buildplaneCurrentTemp) +
                   qsTr(" Please wait <b>%2</b><br>minutes before removing the build<br>plate from the chamber.").arg(time.text)
             font.family: defaultFont.name
             font.pixelSize: 20


### PR DESCRIPTION
BW-5582
http://makerbot.atlassian.net/browse/BW-5582

Re-apply Chamber Temperature labels and temperatures with Buildplane equivalents.

Included several more labels and values this round, and added a dictionary/assoc-array key and value conversion, as cloudprint -sourced meta files did not go through the same filtering steps in the file-to-JSON loader that the meta files coming from USB-keys go through.