### PR TITLE
add visual changes if a logs copy fails

### DIFF
--- a/src/qml/AdvancedSettingsPage.qml
+++ b/src/qml/AdvancedSettingsPage.qml
@@ -38,6 +38,7 @@ AdvancedSettingsPageForm {
                         bot.forceSyncFile(copyingLogsPopup.logBundlePath)
                     }
                     copyLogsFinishedPopup.succeeded = succeeded;
+                    copyLogsFinishedPopup.errorcode = bot.process.errorCode;
                 } else {
                     copyingLogsPopup.zipLogsInProgress = false;
                 }

--- a/src/qml/AdvancedSettingsPageForm.qml
+++ b/src/qml/AdvancedSettingsPageForm.qml
@@ -551,6 +551,7 @@ Item {
 
     ModalPopup {
         property bool succeeded: false
+        property int errorcode: 0
 
         id: copyLogsFinishedPopup
         visible: false
@@ -562,6 +563,27 @@ Item {
                             qsTr("FAILED TO COPY LOGS TO USB")
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
+            }
+            BodyText{
+                visible: !(copyLogsFinishedPopup.succeeded)
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                color: copyLogsFinishedPopup.succeeded ? "#ffffff" : "#ff0000"
+                font.pixelSize: 18
+
+                text: (copyLogsFinishedPopup.errorcode == 1051) ?
+                      qsTr("\n\n\nINSUFFICIENT USB SPACE - REMOVE FILES AND TRY AGAIN") :
+                      qsTr("\n\n\nERROR CODE: " + copyLogsFinishedPopup.errorcode)
+
+                Image {
+                    id: copyLogsFinishedPopupAlertIcon
+                    height: sourceSize.height / 2
+                    width: sourceSize.width / 2
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.verticalCenterOffset: -70
+                    source: "qrc:/img/error.png"
+                }
             }
         }
     }


### PR DESCRIPTION
BW-5612
http://makerbot.atlassian.net/browse/BW-5612

Added error icon image and distinct error report text if a Logs Copying operation fails - to deal with recent uptick in the (edge case?) number of users possibly not noticing the limited visual differences between the existing successful and unsuccessful creation of a logs archive.