### PR TITLE
Get feedback from user for user-cancelled prints as well

### DIFF
--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -34,6 +34,7 @@ class ProcessModel : public BaseModel {
         Paused,
         Completed,
         Failed,
+        Cancelled,
         Idle, // Load and Unload states
         Preheating,
         Extrusion,

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -73,6 +73,8 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
             stateTypeSet(ProcessStateType::Failed);
         else if (kStepStr == "completed")
             stateTypeSet(ProcessStateType::Completed);
+        else if (kStepStr == "cancelled")
+            stateTypeSet(ProcessStateType::Cancelled);
         // 'Load' and 'Unload' states (steps)
         // see morepork-kaiten/kaiten/src/kaiten/processes/loadfilamentprocess.py
         else if (kStepStr == "preheating" ||

--- a/src/qml/FailurePrintFeedback.qml
+++ b/src/qml/FailurePrintFeedback.qml
@@ -1,9 +1,5 @@
 import QtQuick 2.10
 
 FailurePrintFeedbackForm {
-    property var defects: ({})
 
-    function updateFeedbackDict(key, selected) {
-        defects[key] = selected
-    }
 }

--- a/src/qml/FailurePrintFeedbackForm.qml
+++ b/src/qml/FailurePrintFeedbackForm.qml
@@ -100,10 +100,7 @@ Item {
         buttonHeight: 50
         label: qsTr("SUBMIT FEEDBACK")
         button_mouseArea.onClicked: {
-            printFeedbackAcknowledgementPopup.open()
-            printFeedbackAcknowledgementPopup.feedbackGood = false
-            bot.submitPrintFeedback(false, defects)
-            acknowledgePrint()
+            acknowledgePrintFinished.submitFeedbackAndAcknowledge(false)
         }
     }
 }

--- a/src/qml/FeedbackButtonForm.qml
+++ b/src/qml/FeedbackButtonForm.qml
@@ -35,10 +35,11 @@ Rectangle {
     Layout.preferredHeight: height
     Layout.preferredWidth: width
 
-    property bool resetState: printStatusPage.failureFeedbackSelected
+    property bool resetState: acknowledgePrintFinished.failureFeedbackSelected
     onResetStateChanged: {
         if(resetState) {
             selected = false
+            acknowledgePrintFinished.updateFeedbackDict(key, selected)
         }
     }
 
@@ -75,7 +76,7 @@ Rectangle {
         onClicked: {
             if(selected) { selected = false }
             else { selected = true }
-            updateFeedbackDict(key, selected)
+            acknowledgePrintFinished.updateFeedbackDict(key, selected)
         }
     }
 }

--- a/src/qml/PrintIconForm.qml
+++ b/src/qml/PrintIconForm.qml
@@ -33,6 +33,7 @@ LoggingItem {
                 "#3183AF"
                 break;
             case ProcessStateType.Failed:
+            case ProcessStateType.Cancelled:
                 "#F79125"
                 break;
             default:
@@ -81,7 +82,8 @@ LoggingItem {
                       bot.process.stateType == ProcessStateType.CleaningUp ||
                       bot.process.stateType == ProcessStateType.Done || // Part of cancelling step
                       bot.process.stateType == ProcessStateType.Failed ||
-                      bot.process.stateType == ProcessStateType.Completed)
+                      bot.process.stateType == ProcessStateType.Completed ||
+                      bot.process.stateType == ProcessStateType.Cancelled)
 
             RotationAnimator {
                 target: status_image
@@ -306,7 +308,8 @@ LoggingItem {
         },
         State {
             name: "print_failed_state"
-            when: bot.process.stateType == ProcessStateType.Failed
+            when: bot.process.stateType == ProcessStateType.Failed ||
+                  bot.process.stateType == ProcessStateType.Cancelled
 
             PropertyChanges {
                 target: loading_or_paused_image

--- a/src/qml/PrintPage.qml
+++ b/src/qml/PrintPage.qml
@@ -172,6 +172,9 @@ PrintPageForm {
         else if(bot.process.stateType == ProcessStateType.Completed) {
             bot.done("acknowledge_completed")
         }
+        else if(bot.process.stateType == ProcessStateType.Cancelled) {
+            bot.done("acknowledge_failure")
+        }
         if(inFreStep) {
             printStatusView.testPrintComplete = true
         }

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -81,7 +81,8 @@ Item {
 
     FailurePrintFeedback {
         id: failurePrintFeedback
-        visible: bot.process.stateType == ProcessStateType.Completed &&
+        visible: (bot.process.stateType == ProcessStateType.Completed ||
+                 bot.process.stateType == ProcessStateType.Cancelled) &&
                  !bot.process.printFeedbackReported &&
                  acknowledgePrintFinished.failureFeedbackSelected
         z: 1
@@ -134,7 +135,13 @@ Item {
                         0
                     }
                 }
-                spacing: 20
+                spacing: {
+                    if(bot.process.stateType == ProcessStateType.Cancelled) {
+                        -10
+                    } else {
+                        20
+                    }
+                }
 
                 Text {
                     id: status_text0
@@ -163,6 +170,9 @@ Item {
                             break;
                         case ProcessStateType.Failed:
                             qsTr("PRINT FAILED")
+                            break;
+                        case ProcessStateType.Cancelled:
+                            qsTr("PRINT CANCELLED")
                             break;
                         case ProcessStateType.Cancelling:
                             qsTr("CANCELLING")
@@ -315,7 +325,8 @@ Item {
                 AcknowledgePrintFinished {
                     id: acknowledgePrintFinished
                     visible: bot.process.stateType == ProcessStateType.Completed ||
-                             bot.process.stateType == ProcessStateType.Failed
+                             bot.process.stateType == ProcessStateType.Failed ||
+                             bot.process.stateType == ProcessStateType.Cancelled
                 }
             }
         }

--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -214,6 +214,9 @@ Item {
                         case ProcessStateType.Completed:
                             qsTr("PRINT COMPLETE")
                             break;
+                        case ProcessStateType.Cancelled:
+                            qsTr("PRINT CANCELLED")
+                            break;
                         }
                         break;
                     case ProcessType.Load:


### PR DESCRIPTION
Prints cancelled by the user that are reported by users as non-
failure as still reported as failed in the print feedback but the
defects dictionary sent along has the key 'non_failure_other' set
to true, which can be used to isolate these case where the print
attempt was practically a failure for the user but wasn't the fault
of the printer itself.

User-cancelled prints that are reported as failure by the user have
the same feedback workflow as what the failure feedback for a
completed print currently has.

Prints that have failed ie. auto-cancelled due to errors don't prompt
for feedback at all from the user.

BW-5474
https://makerbot.atlassian.net/browse/BW-5474