### PR TITLE
rotate 3 hepa icons to differ from heat warning

### DIFF
--- a/src/qml/images/hepa_filter.png
+++ b/src/qml/images/hepa_filter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:302cd6ccca2f1b67a8a9b2e0570a30f436556072b20e7c1581fc8cd96690da92
-size 525
+oid sha256:0ec8769f1d8d0b04a795716e976c1ead466f47a7a527c801fd61c406c17214a0
+size 497

--- a/src/qml/images/white_hepa_no_blink.gif
+++ b/src/qml/images/white_hepa_no_blink.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93d216fda9e6810459bbcc9ac15ff2de8ff1ff7c8fa945ea16a6de600147717a
-size 3870
+oid sha256:7148973ca3db3986227eb8027a841e3bc1ce2aa056ad322c46b3f2608119c14b
+size 1574

--- a/src/qml/images/yellow_hepa_blink.gif
+++ b/src/qml/images/yellow_hepa_blink.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e37f15c7a498250b4aa601a87f5ac6ac8db055a82af50fe15f54a0a816876a41
-size 2450
+oid sha256:5f2c7b4c74cef977fa8f172e3c53c513cab0f081daa6ab8969768d7f18ac25ef
+size 1352


### PR DESCRIPTION
BW-5434
http://makerbot.atlassian.net/browse/BW-5434

Rotated all 3 hepa icon images in the GIMP image tool to help differentiate them from the ISO hot surface warning symbol.