### PR TITLE
Disable UI touch logging in password input screens

### DIFF
--- a/src/model/bot_model.cpp
+++ b/src/model/bot_model.cpp
@@ -143,6 +143,14 @@ void BotModel::addMakerbotAccount(QString username, QString makerbot_token) {
              << username << "; " <<  makerbot_token;
 }
 
+void BotModel::pause_touchlog() {
+    qDebug() << FL_STRM << "called";
+}
+
+void BotModel::resume_touchlog() {
+    qDebug() << FL_STRM << "called";
+}
+
 void BotModel::zipLogs(QString path) {
     qDebug() << FL_STRM << "called with parameter: " << path;
 }

--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -76,6 +76,8 @@ class BotModel : public BaseModel {
     Q_INVOKABLE virtual void connectWifi(QString path, QString password, QString name);
     Q_INVOKABLE virtual void forgetWifi(QString path);
     Q_INVOKABLE virtual void addMakerbotAccount(QString username, QString makerbot_token);
+    Q_INVOKABLE virtual void pause_touchlog();
+    Q_INVOKABLE virtual void resume_touchlog();
     Q_INVOKABLE virtual void zipLogs(QString path);
     Q_INVOKABLE virtual void forceSyncFile(QString path);
     Q_INVOKABLE virtual void changeMachineName(QString new_name);

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <signal.h>
 
 #include <memory>
 #include <sstream>
@@ -76,6 +77,9 @@ class KaitenBotModel : public BotModel {
     void disconnectWifi(QString path);
     void forgetWifi(QString path);
     void addMakerbotAccount(QString username, QString makerbot_token);
+    void signal_touchlog(int sig);
+    void pause_touchlog();
+    void resume_touchlog();
     void zipLogs(QString path);
     void forceSyncFile(QString path);
     void changeMachineName(QString new_name);
@@ -990,6 +994,40 @@ void KaitenBotModel::addMakerbotAccount(QString username, QString makerbot_token
                 std::weak_ptr<JsonRpcCallback>());
     }
     catch(JsonRpcInvalidOutputStream &e){
+        qWarning() << FFL_STRM << e.what();
+    }
+}
+
+void KaitenBotModel::signal_touchlog(int sig) {
+    // ToDo(William): probably slower than trawling through /proc
+    // directly, but it's definitely less code to maintain
+    uint found_pid_i;
+    FILE * popen_result = popen("pidof -s touch_log", "r");
+    fscanf(popen_result, "%d", &found_pid_i);
+    pclose(popen_result);
+
+    // this sends the passed-in signal (hopefully only SIGUSR1/SIGUSR2
+    // - though the other side was written to only listen for those 2
+    // signals) to the running "touch_log" process
+    kill(found_pid_i, sig);
+}
+
+void KaitenBotModel::pause_touchlog() {
+    try {
+        signal_touchlog(SIGUSR1);
+        LOG(info) << "pause_touchlog()";
+    }
+    catch(JsonRpcInvalidOutputStream &e) {
+        qWarning() << FFL_STRM << e.what();
+    }
+}
+
+void KaitenBotModel::resume_touchlog() {
+    try {
+        signal_touchlog(SIGUSR2);
+        LOG(info) << "resume_touchlog()";
+    }
+    catch(JsonRpcInvalidOutputStream &e) {
         qWarning() << FFL_STRM << e.what();
     }
 }

--- a/src/qml/SignInPageForm.qml
+++ b/src/qml/SignInPageForm.qml
@@ -359,5 +359,14 @@ Item {
             anchors.fill: parent
             active: true
         }
+
+        onVisibleChanged: {
+            if (visible) {
+                bot.pause_touchlog()
+            }
+            if (!visible) {
+                bot.resume_touchlog()
+            }
+        }
     }
 }

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -380,6 +380,14 @@ Item {
                     smooth: false
                     anchors.fill: parent
                 }
+                onVisibleChanged: {
+                    if (visible) {
+                        bot.pause_touchlog()
+                    }
+                    if (!visible) {
+                        bot.resume_touchlog()
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
BW-5613
http://makerbot.atlassian.net/browse/BW-5613

Have QML code pass IPC signals (SIGUSR1 and SIGUSR2) to a targeted
process to toggle off UI-touch logging while interacting with password
screens.

Simplified triggering to detect "on-screen-ness", though due to the
nature of the technique used, will pause touch logging during
Authorization username entry, in addition to Authorization password
entry.