### PR TITLE
add support for new subtype, 2, to 1C extruders

### DIFF
--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -141,6 +141,8 @@ class BotModel : public BaseModel {
     //                properties to it's own sub model.
     MODEL_PROP(ExtruderType, extruderAType, NONE)
     MODEL_PROP(ExtruderType, extruderBType, NONE)
+    MODEL_PROP(int, extruderASubtype, 0)
+    MODEL_PROP(int, extruderBSubtype, 0)
     MODEL_PROP(QString, extruderATypeStr, "mk14")
     MODEL_PROP(QString, extruderBTypeStr, "mk14_s")
     MODEL_PROP(bool, updatingExtruderFirmware, false)

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -1645,6 +1645,7 @@ void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {
                 } else { \
                     extruder ## EXT_SYM ## TypeReset(); \
                 } \
+                UPDATE_INT_PROP(extruder ## EXT_SYM ## Subtype, kExtruder ## EXT_SYM["tool_subtype"]) \
             } else { \
                 extruder ## EXT_SYM ## TypeReset(); \
                 extruder ## EXT_SYM ## TypeStrReset(); \

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -181,7 +181,11 @@ Item {
                 if(bot.machineType == MachineType.Fire) {
                     ["PLA", "Tough", "PETG", "ESD", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF"]
                 } else {
-                    ["PLA", "Tough", "PETG", "ESD", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF", "ABS", "ASA", "PC-ABS", "PC-ABS-FR"]
+                    if (bot.extruderASubtype < 2) {
+                        ["PLA", "Tough", "PETG", "ESD", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF", "ABS", "ASA", "PC-ABS", "PC-ABS-FR"]
+                    } else {
+                        ["PLA", "Tough", "PETG", "ESD", "NYLON", "TPU", "NYLON-CF", "NYLON-12-CF", "ABS", "ASA", "PC-ABS", "PC-ABS-FR", "ABS-R"]
+                    }
                 }
                 break;
             default:


### PR DESCRIPTION
BW-5647
http://makerbot.atlassian.net/browse/BW-5647

Brought forward subtype value (through another patch in machine manager) from existing subtypes-handling code.

Cleaner continuation of prev commit ^^ :

| Lets combine these two identical cases under a single bot.extruderASubtype < 2 case

Simplified handling and behavior of similar subtypes.