### PR TITLE
Added a check for filament bay before checking spool info.

### DIFF
--- a/src/qml/MaterialStatusForm.qml
+++ b/src/qml/MaterialStatusForm.qml
@@ -31,7 +31,7 @@ Item {
                     style: TextBody.ExtraLarge
                     font.weight: Font.Bold
                     text: {
-                        if(spoolPresent && !isUnknownMaterial) {
+                        if(bot.hasFilamentBay && spoolPresent && !isUnknownMaterial) {
                             filamentMaterialName.toUpperCase()
                         } else if((!bot.hasFilamentBay || isUsingExpExtruder(filamentBayID)) && bot.loadedFilaments[filamentBayID - 1] != "None") {
                             (storage.updateMaterialNames(bot.loadedFilaments[filamentBayID-1])).toUpperCase()


### PR DESCRIPTION
BW-5656
http://makerbot.atlassian.net/browse/BW-5656

Based on the logic, even if loaded_filaments is "None" then it would display spool info regardless of whether there is actually filament available at the extruder. While this is applicable when reading spool info from the filament bay, this could be visually confusing when loading and unloading filament for sunflower because there is no filament bay.