### PR TITLE
Bw 5668 cut bent filament screen appears during a purge after a cancelled unload

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -134,12 +134,10 @@ LoggingItem {
         if (currentState != ProcessStateType.UnloadingFilament) {
             doingAutoUnload = false
         }
-
         switch(currentState) {
         case ProcessStateType.Stopping:
         case ProcessStateType.Done:
             snipMaterialAlertAcknowledged = false
-
             delayedEnableRetryButton()
             // (sorry)
             if(bot.process.errorCode > 0 && bot.process.errorCode != 83) {
@@ -147,7 +145,6 @@ LoggingItem {
                 state = "error"
             }
             else if(bot.process.type == ProcessType.Load) {
-
                 // Cancelling Load/Unload ends with 'done' step
                 // but the UI shouldn't go into load/unload
                 // successful state, but to the default state.


### PR DESCRIPTION
BW-5668
http://makerbot.atlassian.net/browse/BW-5668

To stop the cut bent filament screen from appearing when it is unnecessary, the change to check the bayFilamentSwitch was added to the base display page.
Additionally, noticed that when unload is cancelled (and process is cancellable) the materialChangeCancelled flag is not reset which causes the UI to be acting differently in the load state. So the reset of that flag when unload is cancelled as well was added.