### PR TITLE
Added check for filament bay for assisted loading page

### DIFF
--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -119,7 +119,7 @@ MaterialPageForm {
         var current_mat = (bayID == 1 ? bay1.filamentMaterial :
                                 bay2.filamentMaterial)
         var materials = ["tpu", "nylon-cf", "nylon12-cf"]
-        return (materials.indexOf(current_mat) >= 0)
+        return (materials.indexOf(current_mat) >= 0) && bot.hasFilamentBay
     }
 
     function shouldUserAssistPurging(bayID) {


### PR DESCRIPTION
BW-5672
http://makerbot.atlassian.net/browse/BW-5672

Based on how the ticket is written, if we don't want the assisted loading page to come up then the check for hasFilamentBay will only show the page if the filament bay is present.