### PR TITLE
Fix a few more misleadingly named variables

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -178,8 +178,8 @@ Item {
         file_name = file.fileBaseName
         model_extruder_used = file.extruderUsedA
         support_extruder_used = file.extruderUsedB
-        print_model_material = file.materialNameA
-        print_support_material = file.materialNameB
+        print_model_material = file.materialA
+        print_support_material = file.materialB
         uses_support = file.usesSupport ? "YES" : "NO"
         uses_raft = file.usesRaft ? "YES" : "NO"
         model_mass = file.extrusionMassGramsA < 1000 ? file.extrusionMassGramsA.toFixed(1) + " g" :
@@ -551,21 +551,22 @@ Item {
                                             (printTimeHr != 0 ? printTimeHr + "HR " + printTimeMin + "M" : printTimeMin + "M")
                     fileMaterial.text: {
                         if (model.modelData.extruderUsedA && model.modelData.extruderUsedB) {
-                            model.modelData.materialNameA + "+" + model.modelData.materialNameB
+                            bot.getMaterialName(model.modelData.materialA) + "+" +
+                            bot.getMaterialName(model.modelData.materialB)
                         } else if (model.modelData.extruderUsedA && !model.modelData.extruderUsedB) {
-                            model.modelData.materialNameA
+                            bot.getMaterialName(model.modelData.materialA)
                         }
                     }
                     materialError.visible: {
                         if (model.modelData.extruderUsedA && model.modelData.extruderUsedB) {
                             materialPage.bay1.usingExperimentalExtruder ?
-                                (model.modelData.materialNameB != materialPage.bay2.filamentMaterial) :
-                                (model.modelData.materialNameA != materialPage.bay1.filamentMaterial ||
-                                 model.modelData.materialNameB != materialPage.bay2.filamentMaterial)
+                                (model.modelData.materialB != materialPage.bay2.filamentMaterial) :
+                                (model.modelData.materialA != materialPage.bay1.filamentMaterial ||
+                                 model.modelData.materialB != materialPage.bay2.filamentMaterial)
                         } else if (model.modelData.extruderUsedA && !model.modelData.extruderUsedB) {
                             materialPage.bay1.usingExperimentalExtruder ?
                                     false :
-                                    model.modelData.materialNameA != materialPage.bay1.filamentMaterial
+                                    model.modelData.materialA != materialPage.bay1.filamentMaterial
                         }
 
                     }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -256,8 +256,8 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
     MakerbotFileMetaReader file_meta_reader(kFileInfo);
     if(file_meta_reader.loadMetadata()) {
         auto &meta_data = file_meta_reader.meta_data_;
-        QString material_name_a = QString::fromStdString(meta_data->material[0]);
-        QString material_name_b = QString::fromStdString(meta_data->material[1]);
+        QString material_a = QString::fromStdString(meta_data->material[0]);
+        QString material_b = QString::fromStdString(meta_data->material[1]);
         return
             // e.g. "/tmp/archive.tar.gz"
             new PrintFileInfo(
@@ -283,8 +283,8 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
                   meta_data->duration_s,
                   meta_data->uses_support,
                   meta_data->uses_raft,
-                  material_name_a,
-                  material_name_b,
+                  material_a,
+                  material_b,
                   QString::fromStdString(meta_data->slicer_name));
     } else {
         return

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -72,8 +72,8 @@ class PrintFileInfo : public QObject {
   Q_PROPERTY(float timeEstimateSec READ timeEstimateSec NOTIFY fileInfoChanged)
   Q_PROPERTY(bool usesSupport READ usesSupport NOTIFY fileInfoChanged)
   Q_PROPERTY(bool usesRaft READ usesRaft NOTIFY fileInfoChanged)
-  Q_PROPERTY(QString materialNameA READ materialNameA NOTIFY fileInfoChanged)
-  Q_PROPERTY(QString materialNameB READ materialNameB NOTIFY fileInfoChanged)
+  Q_PROPERTY(QString materialA READ materialA NOTIFY fileInfoChanged)
+  Q_PROPERTY(QString materialB READ materialB NOTIFY fileInfoChanged)
   Q_PROPERTY(QString slicerName READ slicerName NOTIFY fileInfoChanged)
 
   QString file_name_, file_path_, file_base_name_;
@@ -85,7 +85,7 @@ class PrintFileInfo : public QObject {
       chamber_temp_celcius_, buildplane_temp_celcius_, num_shells_;
   float layer_height_mm_, infill_density_, time_estimate_sec_;
   bool uses_support_, uses_raft_;
-  QString material_name_a_, material_name_b_, slicer_name_;
+  QString material_a_, material_b_, slicer_name_;
 
   public:
     //MOREPORK_QML_ENUM
@@ -116,8 +116,8 @@ class PrintFileInfo : public QObject {
                   const float time_estimate_sec = 0.0f,
                   const bool uses_support = false,
                   const bool uses_raft = false,
-                  const QString &material_name_a = "null",
-                  const QString &material_name_b = "null",
+                  const QString &material_a = "null",
+                  const QString &material_b = "null",
                   const QString &slicer_name = "null",
                   QObject *parent = 0) :
                   QObject(parent),
@@ -140,8 +140,8 @@ class PrintFileInfo : public QObject {
                   time_estimate_sec_(time_estimate_sec),
                   uses_support_(uses_support),
                   uses_raft_(uses_raft),
-                  material_name_a_(material_name_a),
-                  material_name_b_(material_name_b),
+                  material_a_(material_a),
+                  material_b_(material_b),
                   slicer_name_(slicer_name) { }
 
     PrintFileInfo(const PrintFileInfo &rvalue) {
@@ -164,8 +164,8 @@ class PrintFileInfo : public QObject {
         time_estimate_sec_ = rvalue.time_estimate_sec_;
         uses_support_ = rvalue.uses_support_;
         uses_raft_ = rvalue.uses_raft_;
-        material_name_a_ = rvalue.material_name_a_;
-        material_name_b_ = rvalue.material_name_b_;
+        material_a_ = rvalue.material_a_;
+        material_b_ = rvalue.material_b_;
         slicer_name_ = rvalue.slicer_name_;
     }
 
@@ -190,8 +190,8 @@ class PrintFileInfo : public QObject {
                 rvalue.time_estimate_sec_,
                 rvalue.uses_support_,
                 rvalue. uses_raft_,
-                rvalue.material_name_a_,
-                rvalue.material_name_b_,
+                rvalue.material_a_,
+                rvalue.material_b_,
                 rvalue.slicer_name_);
         return *temp;
     }
@@ -253,11 +253,11 @@ class PrintFileInfo : public QObject {
     bool usesRaft() const {
         return uses_raft_;
     }
-    QString materialNameA() const {
-        return material_name_a_;
+    QString materialA() const {
+        return material_a_;
     }
-    QString materialNameB() const {
-        return material_name_b_;
+    QString materialB() const {
+        return material_b_;
     }
     QString slicerName() const {
         return slicer_name_;


### PR DESCRIPTION
BW-5687
http://makerbot.atlassian.net/browse/BW-5687

MaterialName is for display names and Material is for API names.  We
still had some misleadingly named variables which caused the use of
an API name in a display context to go unnoticed.  This commit adds
the transform function to convert these API names into display names,
and also renames the variables to reflect that they contain API names.