### PR TITLE
Spacing and alignment changes for print status view pages

### DIFF
--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -394,7 +394,7 @@ Item {
                     width: 100
                     height: 100
                     smooth: false
-                    spacing: 65
+                    spacing: 50
 
                     ColumnLayout {
                         id: columnLayout1
@@ -810,6 +810,7 @@ Item {
                     antialiasing: false
                     smooth: false
                     font.pixelSize: 145
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                     font.family: defaultFont.name
                     font.weight: Font.Light
                     font.letterSpacing: 3


### PR DESCRIPTION
BW-5550
http://makerbot.atlassian.net/browse/BW-5550

Was asked to take a look at this ticket after previous changes to print status view and noticed there were some issues.
Reduced spacing on the model page spacing for longer material names. Aligned done by time text to center.