### PR TITLE
update USB storage dev by path for sunflower

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -413,11 +413,13 @@ void MoreporkStorage::newSortType(){
 
 
 void MoreporkStorage::updateUsbStorageConnected(){
-  const bool kUsbStorConnected = QFileInfo(USB_STORAGE_DEV_BY_PATH).exists() ||
-            QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1).exists() ||
-            QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2).exists();
-  const bool kUsbLegacyConnected = QFileInfo(LEGACY_USB_DEV_BY_PATH).exists();
-  usbStorageConnectedSet(kUsbStorConnected || kUsbLegacyConnected);
+  const bool kUsbStorConnected =
+      QFileInfo(USB_STORAGE_DEV_BY_PATH_FRNT_PNL).exists() ||
+      QFileInfo(USB_STORAGE_DEV_BY_PATH_MOBO_PORT_2).exists() ||
+      QFileInfo(USB_STORAGE_DEV_BY_PATH_MOBO_PORT_3).exists() ||
+      QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1).exists() ||
+      QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2).exists();
+  usbStorageConnectedSet(kUsbStorConnected);
   if (!kUsbStorConnected) {
       prog_copy_->cancel(); // cancel copy if one is ongoing
       printFileListReset();

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -35,15 +35,17 @@
 #define CURRENT_THING_PATH QString("/home/current_thing")
 #define TEST_PRINT_PATH QString("/usr/test_prints/")
 #define FIRMWARE_FOLDER_PATH QString("/home/firmware")
-#define USB_STORAGE_DEV_BY_PATH \
+#define USB_STORAGE_DEV_BY_PATH_FRNT_PNL \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1:1.0-scsi-0:0:0:0")
+// MOBO_PORT_2 and MOBO_PORT_3 introduced with motherboard rev-6 (Sunflower)
+#define USB_STORAGE_DEV_BY_PATH_MOBO_PORT_2 \
+QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0\:1.2\:1.0-scsi-0\:0\:0\:0")
+#define USB_STORAGE_DEV_BY_PATH_MOBO_PORT_3 \
+QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0\:1.3\:1.0-scsi-0\:0\:0\:0")
 #define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1 \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1.1:1.0-scsi-0:0:0:0")
 #define USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2 \
 QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.1.2:1.0-scsi-0:0:0:0")
-// TODO(chris): Remove this when we no longer need to support rev B boards
-#define LEGACY_USB_DEV_BY_PATH \
-QString("/dev/disk/by-path/platform-xhci-hcd.1.auto-usb-0:1.4:1.0-scsi-0:0:0:0")
 #define MACHINE_PID_PATH std::string("/usr/settings/PID")
 #endif
 


### PR DESCRIPTION
Sunflower rev-6 motherboards add a USB hub on the motherboard itself
that could probably be used for storage devices. We also do some
testing/lab stuff using these ports. This change adds the 'dev by path'
for the motherboard USB ports and also removes a legacy port for rev-b
motherboards.