### PR TITLE
Fix blank screen in print page on clicking change material

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -24,8 +24,8 @@ ErrorScreenForm {
     }
 
     function resetSwipeViews() {
-        if(printPage.printStatusView.printStatusSwipeView.currentIndex != 0) {
-            printPage.printStatusView.printStatusSwipeView.setCurrentIndex(0)
+        if(printPage.printStatusView.printStatusSwipeView.currentIndex != PrintStatusView.Page0) {
+            printPage.printStatusView.printStatusSwipeView.setCurrentIndex(PrintStatusView.Page0)
         }
         if(mainSwipeView.currentIndex != MoreporkUI.BasePage) {
             mainSwipeView.swipeToItem(MoreporkUI.BasePage)

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -2849,9 +2849,7 @@ ApplicationWindow {
 
                             function resetDetailsAndGoToMaterialsPage() {
                                 printPage.resetPrintFileDetails()
-                                if(printPage.printSwipeView.currentIndex != PrintPage.BasePage) {
-                                    printPage.printSwipeView.setCurrentIndex(PrintPage.BasePage)
-                                }
+                                printPage.printSwipeView.swipeToItem(PrintPage.BasePage)
                                 mainSwipeView.swipeToItem(MoreporkUI.MaterialPage)
                             }
 


### PR DESCRIPTION
SwipeViews used as page containers are implemented using the
LoggingSwipeView component which has its own SwipeToItem function,
which in addition to swiping does a few more things viz. logging
actions and toggling visibilities of the pages.

The bug here was that the swipe was being perforemed directly
by manipulating the current index, bypassing the swipeToItem
function, which was causing the visibility issue.

BW-5681
https://makerbot.atlassian.net/browse/BW-5681