### PR TITLE
Always let labs select material/temperature

### DIFF
--- a/src/model/bot_model.cpp
+++ b/src/model/bot_model.cpp
@@ -68,8 +68,8 @@ void BotModel::loadFilamentStop() {
     qDebug() << FL_STRM << "called";
 }
 
-void BotModel::unloadFilament(const int kToolIndex, bool external, bool whilePrinting, QList<int> temperature) {
-    qDebug() << FL_STRM << "called with tool_index: " << kToolIndex << " temperature: " << temperature[kToolIndex] << " external: " << external << " whilePrinting " << whilePrinting;
+void BotModel::unloadFilament(const int kToolIndex, bool external, bool whilePrinting, QList<int> temperature, QString material) {
+    qDebug() << FL_STRM << "called with tool_index: " << kToolIndex << " temperature: " << temperature[kToolIndex] << " material: " << material << " external: " << external << " whilePrinting " << whilePrinting;
 }
 
 void BotModel::assistedLevel() {

--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -54,7 +54,7 @@ class BotModel : public BaseModel {
             bool whilePrinting, QList<int> temperature = {0,0}, QString material="None");
     Q_INVOKABLE virtual void loadFilamentStop();
     Q_INVOKABLE virtual void unloadFilament(const int kToolIndex, bool external,
-            bool whilePrinting, QList<int> temperature = {0,0});
+            bool whilePrinting, QList<int> temperature = {0,0}, QString material="None");
     Q_INVOKABLE virtual void assistedLevel();
     Q_INVOKABLE virtual void acknowledge_level();
     Q_INVOKABLE virtual void continue_leveling();

--- a/src/qml/LoadMaterialSelectorForm.qml
+++ b/src/qml/LoadMaterialSelectorForm.qml
@@ -76,7 +76,7 @@ ListSelector {
         smooth: false
         antialiasing: false
         onClicked: {
-            startLoadForMaterial(toolIdx, false, model.modelData)
+            startLoadUnloadForMaterial(toolIdx, model.modelData)
         }
     }
     footer:

--- a/src/qml/LoadMaterialSettingsForm.qml
+++ b/src/qml/LoadMaterialSettingsForm.qml
@@ -12,8 +12,12 @@ Item {
     property alias tempSelectorPage: tempSelectorPage
     property alias selectMaterialSwipeView: selectMaterialSwipeView
 
-    function startLoadForMaterial(tool_idx, external, material) {
-        load(tool_idx, external, [0,0], material)
+    function startLoadUnloadForMaterial(tool_idx, material) {
+        if(isLoadFilament) {
+            load(tool_idx, false, [0,0], material)
+        } else {
+            unload(tool_idx, true, [0,0], material)
+        }
     }
 
     function startLoadUnloadCustomTemperature(tool_idx, temperature) {


### PR DESCRIPTION
BW-5704
http://makerbot.atlassian.net/browse/BW-5704

The new flow for sunflower lets the user select a material when loading filament
while idle, and has kaiten remember this filament so that it won't have to ask
the user the material type for unloading or purging, or for loading in the
middle of a print.  We then reused this exact flow for the labs extruder, adding
only an option just for labs to use a custom temperature when loading.  But
there are a few problems here.

* If a user selects a custom temperature when loading, we do at a minimum need
  to give that user the option to select a custom temperature for every unload
  or purge that follows.
* If a user has labs filament loaded when they upgrade from 1.11 to 1.12, kaiten
  doesn't know what they have loaded and just tries to unload it at 180C.

Additionally, users do currently have the option for LABS to select one material
for loading temperature and a different material for unloading without actually
knowing what those temperatures are (and also the temperature selection wheel is
a bit more of a pain to use than just selecting a material), so we still need
some discussion before trying to match the sunflower flow in all cases except a
custom temperature.

This commit generally restores the outward behavior of labs in 1.11, allowing
(and requiring) the temperature to be selected before every load, unload and
purge.  Behind the scenes we add a path for every load, unload and purge to
pass a material name to kaiten so that kaiten will use the temperatures for
the given material without the UI needing to know what these temperatures are.

Also I patched in the fix for purge buttons being accessible during a print so
that I could also test that at the same time and then put it into the same
hotfix release.