### PR TITLE
trim decimals from cloud queue build plane temps

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -223,7 +223,7 @@ Item {
         extruder_temp = !support_extruder_used ?
                             meta['extruder_temperatures'][0] + "C" :
                             meta['extruder_temperatures'][0] + "C" + " + " + meta['extruder_temperatures'][1] + "C"
-        buildplane_temp = Math.floor(meta['buildplane_target_temperature']) + "C"
+        buildplane_temp = Math.round(meta['buildplane_target_temperature']) + "C"
         getPrintTimes(printTimeSec)
         printQueuePopup.close()
         if(!startPrintMaterialCheck()) {


### PR DESCRIPTION
BW-5696
http://makerbot.atlassian.net/browse/BW-5696

On the rare occasion that the cloud slicer does not correctly return
an integer value for the build plane temperature for a slice, we will
make it so.