### PR TITLE
Allow load for sunflower when filament present but null material

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -247,7 +247,8 @@ Item {
                 id: loadButton
                 text: qsTr("LOAD")
                 logKey: text
-                visible: !extruderFilamentPresent
+                visible: !extruderFilamentPresent ||
+                         (!bot.hasFilamentBay && filamentMaterial == "unknown")
             }
 
             ButtonRectangleSecondary {
@@ -260,7 +261,8 @@ Item {
                 id: purgeButton
                 text: qsTr("PURGE")
                 logKey: text
-                visible: extruderFilamentPresent
+                visible: (bot.hasFilamentBay) ? extruderFilamentPresent :
+                         (extruderFilamentPresent && filamentMaterial != "unknown")
             }
         }
     }


### PR DESCRIPTION
BW-5700
http://makerbot.atlassian.net/browse/BW-5700

For Sunflower, if there is no material information saved in loaded filaments, but the filament switch is triggered we want the user to be able to load and select materials (via the Load button). The Unload button remains enabled if the filament switch is triggered regardless of whether we display Load or Purge buttons.