### PR TITLE
close window upon removal/disconnect of 1C extr

### DIFF
--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -41,6 +41,7 @@ Item {
     property bool isMaterialMismatch: false
 
     property alias moistureWarningPopup: moistureWarningPopup
+
     property alias uncapped1CExtruderAlert: uncapped1CExtruderAlert
     property bool restartPendingAfterExtruderReprogram: false
 
@@ -841,6 +842,8 @@ Item {
     }
 
     CustomPopup {
+        property bool extruderAPresent: bot.extruderAPresent
+
         popupName: "Uncapped1CExtruderAlert"
         id: uncapped1CExtruderAlert
         popupWidth: 750
@@ -880,6 +883,14 @@ Item {
                 popupState = "reprogrammed"
             } else if(popupState == "reprogrammed" || popupState == "restart_pending") {
                 bot.reboot()
+            }
+        }
+
+        onExtruderAPresentChanged: {
+            // Upon removal of the 1C extruder...
+            if(!extruderAPresent) {
+                // equivalent to activating the above "BACK" button
+                uncapped1CExtruderAlert.close()
             }
         }
 


### PR DESCRIPTION
BW-5706
http://makerbot.atlassian.net/browse/BW-5706

Disallow offering to reprogram extruder (intended for 1C.0 to 1C.2 conversions) by closing alert window, upon detecting removal of model extruder from bot.

Should prevent allowing the reprogramming of any other extruder to 1C.2.