### PR TITLE
Use supported materials from kaiten for materials check

### DIFF
--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -99,29 +99,15 @@ Item {
 
     property bool isMaterialValid: {
         skipMaterialChecks ||
-        supportedMaterialsList.indexOf(filamentMaterial) >= 0
+        supportedMaterials.indexOf(filamentMaterial) >= 0
     }
 
     function checkSliceValid(material) {
         return usingExperimentalExtruder ||
-            supportedMaterialsList.indexOf(material) >= 0;
+            supportedMaterials.indexOf(material) >= 0;
     }
 
-    property var supportedMaterialsList: {
-        // Get the supported materials list from kaiten
-        // based on the extruder
-        switch(filamentBayID) {
-        case 1:
-            bot.extruderASupportedMaterials
-            break;
-        case 2:
-            bot.extruderBSupportedMaterials
-            break;
-        default:
-            []
-            break;
-        }
-    }
+    property var supportedMaterials: bot["extruder%1SupportedMaterials".arg(idxAsAxis)]
 
     property string printMaterial : {
         switch(filamentBayID) {

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -507,7 +507,7 @@ Item {
                                     qsTr("Only ABS and ASA model material are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.")
                                     break;
                                 case ExtruderType.MK14_COMP:
-                                    qsTr("Only %1 model materials are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.").arg(materialPage.bay1.supportedMaterialsList.map(bot.getMaterialName).join(", "))
+                                    qsTr("Only %1 model materials are compatible in material bay 1. Insert MakerBot model material in material bay 1 to continue.").arg(materialPage.bay1.supportedMaterials.map(bot.getMaterialName).join(", "))
                                     break;
                                 }
                             } else if(loadUnloadFilamentProcess.currentActiveTool == 2) {


### PR DESCRIPTION
BW-5680
http://makerbot.atlassian.net/browse/BW-5680

Replaced the "goodMaterialsList" with the supported materials list that is created in kaiten and used for the sunflower load process. Kaiten will handle the check for high temp materials on fire, to prevent high temp materials from being in the supported materials list. Updated places where this is used.