### PR TITLE
Reset material page states and return to print screen on starting print

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -105,6 +105,13 @@ Item {
             printStatusView.acknowledgePrintFinished.failureFeedbackSelected = false // Reset when print starts
             showPrintTip()
             startPrintSource = PrintPage.None
+
+            // Reset material page states when (an external) print process starts
+            // so that the user isn't stuck on the material loading screen if
+            // they had it open. Since this is the same cleanup signal at the
+            // end of (mid-print) loading it takes us directly to the printing
+            // screen too as a good side effect.
+            materialPage.loadUnloadFilamentProcess.processDone()
         }
         else {
             printStatusView.printStatusSwipeView.setCurrentIndex(PrintStatusView.Page0)


### PR DESCRIPTION
Emitting the processDone() signal (as during the end of a mid-print load) conveniently takes us directly to the printing screen as if a mid-print load was completed.

BW-5719
https://makerbot.atlassian.net/browse/BW-5719