### PR TITLE
Scroll the ethernet text with the wifi list + other wifi fixes

### DIFF
--- a/src/model/net_model.h
+++ b/src/model/net_model.h
@@ -87,7 +87,6 @@ class NetModel : public BaseModel {
   public:
     //MOREPORK_QML_ENUM
     enum WifiState {
-         Searching,
          NoWifiFound,
          Connecting,
          Disconnecting,
@@ -140,6 +139,7 @@ class NetModel : public BaseModel {
     MODEL_PROP(QString, wlanMacAddr, "Unknown")
     MODEL_PROP(QStringList, dns, {"Unknown"})
     MODEL_PROP(bool, wifiEnabled, false)
+    MODEL_PROP(bool, wifiSearching, false)
     MODEL_PROP(WifiState, wifiState, NotConnected)
     MODEL_PROP(WifiError, wifiError, NoError)
     MODEL_PROP(bool, analyticsEnabled, false)

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -938,6 +938,7 @@ void KaitenBotModel::scanWifi(bool forceRescan){
         Json::Value json_params(Json::objectValue);
         json_params["force_rescan"] = Json::Value(forceRescan);
         conn->jsonrpc.invoke("wifi_scan", json_params, m_wifiCb);
+        dynamic_cast<KaitenNetModel*>(m_net.data())->setWifiSearching();
     }
     catch(JsonRpcInvalidOutputStream &e){
         qWarning() << FFL_STRM << e.what();

--- a/src/model_impl/kaiten_net_model.cpp
+++ b/src/model_impl/kaiten_net_model.cpp
@@ -71,11 +71,11 @@ void KaitenNetModel::wifiUpdate(const Json::Value &result) {
         }
 
         if (wifi_list.empty()) {
-            wifiStateSet(WifiState::NoWifiFound);
             WiFiListReset();
         } else {
             WiFiListSet(wifi_list);
         }
+        wifiSearchingSet(false);
     }
 
     // wifi_connect(...) part
@@ -95,6 +95,10 @@ void KaitenNetModel::wifiUpdate(const Json::Value &result) {
             }
         }
     }
+}
+
+void KaitenNetModel::setWifiSearching() {
+    wifiSearchingSet(true);
 }
 
 void KaitenNetModel::cloudServicesInfoUpdate(const Json::Value &result) {

--- a/src/model_impl/kaiten_net_model.h
+++ b/src/model_impl/kaiten_net_model.h
@@ -13,6 +13,7 @@ class KaitenNetModel : public NetModel {
     void wifiUpdate(const Json::Value &result);
     void cloudServicesInfoUpdate(const Json::Value &result);
     void printQueueUpdate(const Json::Value &queue);
+    void setWifiSearching();
 };
 
 #endif  // _SRC_KAITEN_NET_MODEL_H

--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -63,7 +63,6 @@ FrePageForm {
                 else {
                     inFreStep = true
                     bot.toggleWifi(true)
-                    bot.net.setWifiState(WifiState.Searching)
                     bot.scanWifi(true)
                     mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                     settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)

--- a/src/qml/SystemSettingsPage.qml
+++ b/src/qml/SystemSettingsPage.qml
@@ -21,7 +21,6 @@ SystemSettingsPageForm {
         }
         else if(bot.net.wifiState == WifiState.NotConnected ||
                 bot.net.wifiState == WifiState.NoWifiFound) {
-            bot.net.setWifiState(WifiState.Searching)
             bot.scanWifi(true)
         }
         systemSettingsSwipeView.swipeToItem(SystemSettingsPage.WifiPage)

--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -296,9 +296,9 @@ Item {
                                     qsTr("%1 SENSOR INFO").arg(bot.name)
                                     break;
                                 case SystemSettingsPage.WifiPage:
-                                    switch(settingsPage.wifiPage.wifiSwipeView.currentIndex) {
+                                    switch(settingsPage.systemSettingsPage.wifiPage.wifiSwipeView.currentIndex) {
                                     case WiFiPage.EnterPassword:
-                                       var wifiNameRefactor = (qsTr("%1").arg(settingsPage.wifiPage.selectedWifiName))
+                                       var wifiNameRefactor = (qsTr("%1").arg(settingsPage.systemSettingsPage.wifiPage.selectedWifiName))
                                        if(wifiNameRefactor.length > 8) {
                                             wifiNameRefactor= wifiNameRefactor.substr(0,8) + "..."
                                         }

--- a/src/qml/WiFiPageEthernet.qml
+++ b/src/qml/WiFiPageEthernet.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.10
+
+WiFiPageEthernetForm {
+
+}
+

--- a/src/qml/WiFiPageEthernetForm.qml
+++ b/src/qml/WiFiPageEthernetForm.qml
@@ -1,0 +1,47 @@
+import QtQuick 2.10
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import WifiStateEnum 1.0
+import WifiErrorEnum 1.0
+
+ColumnLayout {
+    spacing: 15
+    Layout.alignment: Qt.AlignHCenter
+
+    Image {
+        id: ethernet_image
+        Layout.preferredWidth: 30
+        Layout.preferredHeight: 30
+        Layout.alignment: Qt.AlignHCenter
+        source: {
+            if(bot.net.interface == "ethernet") {
+                "qrc:/img/process_complete_small.png"
+            } else {
+                "qrc:/img/ethernet_connected.png"
+            }
+        }
+    }
+
+    TextBody {
+        font.pixelSize: 13
+        font.weight: Font.Bold
+        Layout.alignment: Qt.AlignHCenter
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+
+        Layout.preferredWidth: 400
+        text: {
+            if(bot.net.interface == "ethernet") {
+                "You’re connected to the internet through the ethernet port."
+            } else {
+                "Plug an ethernet cable into the rear of the machine to use a wired connection."
+            }
+        }
+    }
+
+    // Extra space at the bottom
+    Item {
+        height: 0
+        width: 1
+    }
+}

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -12,6 +12,7 @@ Item {
     smooth: false
     antialiasing: false
     property alias wifiSwipeView: wifiSwipeView
+    property alias wifiList: wifiList
     property int wifiError: bot.net.wifiError
     property bool isWifiConnected: bot.net.interface == "wifi"
     property string currentWifiName: bot.net.name
@@ -19,6 +20,11 @@ Item {
     property string selectedWifiName: ""
     property bool selectedWifiSaved: false
     property bool isForgetEnabled: false
+    property bool listVisible: bot.net.wifiEnabled && (isWifiConnected ||
+        bot.net.wifiState == WifiState.Connected ||
+        (bot.net.wifiState == WifiState.NotConnected &&
+         bot.net.wifiError != WifiError.ScanFailed &&
+         bot.net.wifiError != WifiError.UnknownError))
 
     onIsWifiConnectedChanged: {
         if(isWifiConnected) {
@@ -98,52 +104,27 @@ Item {
             }
 
             ColumnLayout {
-                id: ethernetInfoId
+                id: refreshButton
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 anchors.topMargin: 10
                 spacing: 15
 
-                Image {
-                    id: ethernet_image
-                    Layout.preferredWidth: 30
-                    Layout.preferredHeight: 30
-                    Layout.alignment: Qt.AlignHCenter
-                    source: {
-                        if(bot.net.interface == "ethernet") {
-                            "qrc:/img/process_complete_small.png"
-                        } else {
-                            "qrc:/img/ethernet_connected.png"
-                        }
-                    }
-                }
-                TextBody {
-                    font.pixelSize: 13
-                    font.weight: Font.Bold
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.WordWrap
-
-                    Layout.preferredWidth: 400
-                    text: {
-                        if(bot.net.interface == "ethernet") {
-                            "You’re connected to the internet through the ethernet port."
-                        } else {
-                            "Plug an ethernet cable into the rear of the machine to use a wired connection."
-                        }
-                    }
-                }
                 ButtonRectangleSecondary {
                     width: 750
                     Layout.preferredWidth: 750
                     text: "SCAN WI-FI NETWORKS"
                     Layout.alignment: Qt.AlignHCenter
-                    enabled: (bot.net.wifiState !== WifiState.Searching)
+                    enabled: bot.net.interface !== "ethernet" &&
+                        bot.net.wifiEnabled && !bot.net.wifiSearching
 
                     onClicked: {
                         bot.scanWifi(true)
-                        bot.net.setWifiState(WifiState.Searching)
                     }
+                }
+
+                WiFiPageEthernet {
+                    visible: !listVisible
                 }
 
                 // When the bot is not connected to wifi and the user
@@ -156,7 +137,7 @@ Item {
                     text: {
                         if(!bot.net.wifiEnabled) {
                             qsTr("Turn on WiFi and try again.")
-                        } else if ((wifiList.count == 0) && (bot.net.wifiState == WifiState.Searching)) {
+                        } else if ((wifiList.count === 0) && (bot.net.wifiSearching)) {
                             qsTr("Searching...")
                         } else if (bot.net.wifiState == WifiState.NoWifiFound) {
                             qsTr("No wireless networks found.")
@@ -169,11 +150,7 @@ Item {
                     }
                     Layout.alignment: Qt.AlignCenter
                     Layout.topMargin: 60
-                    visible: (wifiList.count == 0 && bot.net.wifiState == WifiState.Searching) ||
-                             bot.net.wifiState == WifiState.NoWifiFound ||
-                             (bot.net.wifiState == WifiState.NotConnected &&
-                              (bot.net.wifiError == WifiError.ScanFailed ||
-                               bot.net.wifiError == WifiError.UnknownError))
+                    visible: !listVisible && bot.net.interface !== "ethernet"
                 }
             }
 
@@ -204,7 +181,7 @@ Item {
                 id: wifiList
                 smooth: false
                 antialiasing: false
-                anchors.top: ethernetInfoId.bottom
+                anchors.top: refreshButton.bottom
                 anchors.topMargin: 20
                 anchors.left: parent.left
                 anchors.right: parent.right
@@ -214,13 +191,13 @@ Item {
                 orientation: ListView.Vertical
                 flickableDirection: Flickable.VerticalFlick
                 clip: true
-                visible: (bot.net.wifiState == WifiState.Connected ||
-                         isWifiConnected ||
-                         (bot.net.wifiState == WifiState.NotConnected &&
-                                bot.net.wifiError != WifiError.ScanFailed &&
-                                bot.net.wifiError != WifiError.UnknownError) ||
-                         (bot.net.wifiState === WifiState.Searching && count != 0))
+                visible: listVisible
                 model: bot.net.WiFiList
+
+                header: WiFiPageEthernet {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.bottomMargin: 15
+                }
 
                 delegate:
                     WiFiButton {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -255,6 +255,8 @@
         <file>AdvancedInfoDragonItemForm.qml</file>
         <file>WiFiButton.qml</file>
         <file>WiFiButtonForm.qml</file>
+        <file>WiFiPageEthernet.qml</file>
+        <file>WiFiPageEthernetForm.qml</file>
         <file>ExtruderSettingsPageForm.qml</file>
         <file>ExtruderSettingsPage.qml</file>
         <file>BuildPlateSettingsPage.qml</file>


### PR DESCRIPTION
The idea here is that the reset button is always on top of the ethernet text and when we are showing a wifi list the ethernet text is the header element of the list (so that it scrolls with the list).  We make two copies of the ethernet text so that we also have a non scrolling version to show when the list is not visible (though I am not entirely clear on why we can't always show the list or whether we really need the ethernet text in the cases where we don't show the list).

This also changes around the logic to disable attempted use of wifi while ethernet is attached because this really does not work well, and changes the scanning logic to separately track whether we are actively scanning and whether we are currently connected, because apparently the rescan button has been completely unusable since 1.5 if you aren't already connected to wifi.  This also fixes the top bar title.