### PR TITLE
Compile qml at build time instead of runtime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 # so this just magically works.
 find_package(Qt5 COMPONENTS Core Quick Multimedia Gui REQUIRED)
 find_package(Qt5LinguistTools)
+find_package(Qt5QuickCompiler)
 
 # Model impl sources aren't built for Qt creator so they just live here
 set(SOURCES
@@ -123,19 +124,19 @@ qt5_wrap_cpp(MOREPORK_UI_HEADERS_MOC
 file(GLOB TS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/translations/*.ts")
 qt5_add_translation(QM_FILES ${TS_SOURCES})
 
-qt5_add_resources(MOREPROK_UI_RESOURCES qml/media.qrc qml/qml.qrc)
+qtquick_compiler_add_resources(MOREPORK_UI_RESOURCES qml/media.qrc qml/qml.qrc)
 
 # Take care of host code
 if(${QT_CREATOR_BUILD})
     include_directories(host)
-    qt5_add_resources(MOREPROK_HOST_UI_RESOURCES host/host.qrc)
-    list(APPEND MOREPROK_UI_RESOURCES ${MOREPROK_HOST_UI_RESOURCES})
+    qt5_add_resources(MOREPORK_HOST_UI_RESOURCES host/host.qrc)
+    list(APPEND MOREPORK_UI_RESOURCES ${MOREPORK_HOST_UI_RESOURCES})
     list(APPEND SOURCES host/host_model.cpp)
 endif()
 
 add_executable(morepork_ui
     ${SOURCES}
-    ${MOREPROK_UI_RESOURCES}
+    ${MOREPORK_UI_RESOURCES}
     ${QM_FILES}
     ${MOREPORK_UI_HEADERS_MOC})
 target_link_libraries(morepork_ui


### PR DESCRIPTION
QML modules are compiled before use.  Currently this just happens every time that we load the UI application (there is a mechanism for caching these files but that does not work due to the read only filesystem). However there is support for compiling these modules at compile time and bundling the compiled versions into the binary along with the QML files themselves (which according to the docs are also used in some cases).

This commit adds compiled qml into the binary at compile time so that the compilation step can be skipped at runtime.  This is accomplished through a QML module (that we already build with buildroot) which just replaces the qt5_add_resources call with a call that also compiles qml for every qml file listed in a qrc file.

I measured one time each the time to restart the UI when the system is idle before and after this change and got 46 seconds before and 33 seconds after.  The file size was 32MB before and 34MB after.  The time improvement isn't actually that impressive and with only one sample isn't even statisticaly significant.

But I still think that this is worth doing because we get a build time check that all of our qml files are valid.