### PR TITLE
Use the blocking firmware URL for downloads

### DIFF
--- a/src/qml/FirmwareUpdatePageForm.qml
+++ b/src/qml/FirmwareUpdatePageForm.qml
@@ -59,7 +59,7 @@ LoggingItem {
     property bool updateFirmware: false
 
     function getUrlForMethod() {
-           return "support.makerbot.com/s/article/Method-Firmware"
+           return "makerbot.com/methodfw"
     }
 
     Rectangle {


### PR DESCRIPTION
BW-5784
http://makerbot.atlassian.net/browse/BW-5784

This shortcut URL currently directs to the generic firmware page for method and method X (that will probably also eventually support host method XL firmware) and if the supprt page gets reorganized again we can just update the shortcut on the website.