### PR TITLE
Hide untuned features from the UI for sunflower

### DIFF
--- a/src/qml/SettingsPageForm.qml
+++ b/src/qml/SettingsPageForm.qml
@@ -5,6 +5,7 @@ import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
 import FreStepEnum 1.0
 import ErrorTypeEnum 1.0
+import MachineTypeEnum 1.0
 
 Item {
     id: settingsPage
@@ -105,6 +106,7 @@ Item {
                         buttonText.text: qsTr("CLEAN AIR SETTINGS")
                         buttonText.anchors.leftMargin: 38
                         buttonAlertImage.visible: bot.hepaFilterChangeRequired
+                        visible: bot.machineType != MachineType.Magma
                     }
 
                     MenuButton {
@@ -112,6 +114,7 @@ Item {
                         buttonImage.source: "qrc:/img/icon_preheat.png"
                         buttonText.text: qsTr("PREHEAT")
                         enabled: !isProcessRunning()
+                        visible: bot.machineType != MachineType.Magma
                     }
 
                     MenuButton {
@@ -119,6 +122,7 @@ Item {
                         buttonImage.source: "qrc:/img/icon_material.png"
                         buttonText.text: qsTr("DRY MATERIAL")
                         enabled: !isProcessRunning()
+                        visible: bot.machineType != MachineType.Magma
                     }
 
                     MenuButton {
@@ -126,6 +130,7 @@ Item {
                         buttonImage.source: "qrc:/img/icon_anneal_print.png"
                         buttonText.text: qsTr("ANNEAL PRINT")
                         enabled: !isProcessRunning()
+                        visible: bot.machineType != MachineType.Magma
                     }
 
                     MenuButton {


### PR DESCRIPTION
Hide Anneal Print, Dry Material, Preheat, Clean Air Settings

I thought of adding a flag to the settings that can override and show these hidden settings on sunflower if internal users wanted to access them for development or tuning but decided against it since these settings as they are now don't support selecting custom values from the UI to be able to be used easily for tuning.

BW-5772
https://makerbot.atlassian.net/browse/BW-5772