### PR TITLE
[BW-5762] Fixed allignment of NPS survey

### DIFF
--- a/src/qml/TextBodyForm.qml
+++ b/src/qml/TextBodyForm.qml
@@ -8,9 +8,7 @@ Text {
         ExtraLarge
     }
     property int style: TextBody.Base
-    property int text_width: 360
     id: textBody
-    width: text_width
     text: "text-base"
     font.family: "Roboto"
     font.pixelSize: {


### PR DESCRIPTION
- Moved the TextBody to the contentItem instead of being an indicator
- Added text allignment features over anchor allignment