### PR TITLE
Typo fix for load/unload retry during a print

### DIFF
--- a/src/qml/LoadUnloadFilament.qml
+++ b/src/qml/LoadUnloadFilament.qml
@@ -64,7 +64,7 @@ LoadUnloadFilamentForm {
             if(bot.process.type == ProcessType.None) {
                 while_printing = false;
             } else if(bot.process.type == ProcessType.Print) {
-                while_printing = false;
+                while_printing = true;
             } else {
                 return;
             }


### PR DESCRIPTION
The retry button was found to be no longer working during a print -- a typo during this refactor appears to be the cause.