### PR TITLE
Updates for name printer and cloud connect

### DIFF
--- a/src/model/fre_tracker.h
+++ b/src/model/fre_tracker.h
@@ -21,7 +21,6 @@ class FreTracker : public BaseModel {
         Welcome,
         SetupWifi,
         SoftwareUpdate,
-        NamePrinter,
         SetTimeDate,
         SunflowerUnpacking,
         AttachExtruders,
@@ -29,6 +28,7 @@ class FreTracker : public BaseModel {
         CalibrateExtruders,
         LoadMaterial,
         TestPrint,
+        NamePrinter,
         LoginMbAccount,
         SetupComplete,
         FreComplete
@@ -61,7 +61,6 @@ class FreTracker : public BaseModel {
         "welcome",
         "setup_wifi",
         "software_update",
-        "name_prnter",
         "set_time_date",
         "sunflower_unpacking",
         "attach_extruders",
@@ -69,6 +68,7 @@ class FreTracker : public BaseModel {
         "calibrate_extruders",
         "load_material",
         "test_print",
+        "name_printer",
         "login_mb_account",
         "setup_complete",
         "fre_complete"

--- a/src/qml/AuthorizeAccountPage.qml
+++ b/src/qml/AuthorizeAccountPage.qml
@@ -100,6 +100,12 @@ AuthorizeAccountPageForm {
         onTriggered: {
             closePopup()
             backToSettings()
+            if (inFreStep) {
+                systemSettingsSwipeView.swipeToItem(SystemSettingsPage.BasePage)
+                settingsSwipeView.swipeToItem(SettingsPage.BasePage)
+                mainSwipeView.swipeToItem(MoreporkUI.BasePage)
+                fre.gotoNextStep(currentFreStep)
+            }
         }
     }
 }

--- a/src/qml/AuthorizeAccountPageForm.qml
+++ b/src/qml/AuthorizeAccountPageForm.qml
@@ -101,10 +101,24 @@ Item {
             visible: false
 
             function altBack() {
+                if(!inFreStep) {
+                    authorizeAccountWithCodePage.disconnectHandlers()
+                    authorizeAccountWithCodePage.checkAuthTimer.stop()
+                    authorizeAccountWithCodePage.expireOTPTimer.stop()
+                    authorizeAccountSwipeView.swipeToItem(AuthorizeAccountPage.ChooseAuthMethod)
+                } else {
+                    skipFreStepPopup.open()
+                }
+            }
+
+            function skipFreStepAction() {
                 authorizeAccountWithCodePage.disconnectHandlers()
                 authorizeAccountWithCodePage.checkAuthTimer.stop()
                 authorizeAccountWithCodePage.expireOTPTimer.stop()
                 authorizeAccountSwipeView.swipeToItem(AuthorizeAccountPage.ChooseAuthMethod)
+                backToSettings()
+                settingsSwipeView.swipeToItem(SettingsPage.BasePage)
+                mainSwipeView.swipeToItem(MoreporkUI.BasePage)
             }
 
             AuthorizeAccountWithCode {

--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -53,12 +53,7 @@ FrePageForm {
 
             if(state == "wifi_setup") {
                 if(isNetworkConnectionAvailable) {
-                    if(isfirmwareUpdateAvailable) {
-                        fre.gotoNextStep(currentFreStep)
-                    }
-                    else {
-                        fre.setFreStep(FreStep.NamePrinter)
-                    }
+                    fre.gotoNextStep(currentFreStep)
                 }
                 else {
                     inFreStep = true
@@ -74,12 +69,6 @@ FrePageForm {
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                 settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
                 settingsPage.systemSettingsPage.systemSettingsSwipeView.swipeToItem(SystemSettingsPage.FirmwareUpdatePage)
-            } else if(state == "name_printer") {
-                inFreStep = true
-                mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
-                settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
-                settingsPage.systemSettingsPage.systemSettingsSwipeView.swipeToItem(SystemSettingsPage.ChangePrinterNamePage)
-                settingsPage.namePrinter.nameField.forceActiveFocus()
             } else if(state == "set_time_date") {
                 inFreStep = true
                 bot.getSystemTime()
@@ -110,21 +99,29 @@ FrePageForm {
                 inFreStep = true
                 startTestPrint()
             } else if(state == "log_in") {
-                // login has a separate flow within the fre screen.
-            } else if(state == "setup_complete") {
-                fre.setFreStep(FreStep.FreComplete)
+                inFreStep = true
+                mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
+                settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
+                settingsPage.systemSettingsPage.systemSettingsSwipeView.swipeToItem(SystemSettingsPage.AuthorizeAccountsPage)
+                settingsPage.systemSettingsPage.authorizeAccountPage.authorizeAccountWithCodePage.beginAuthWithCode()
+                settingsPage.systemSettingsPage.authorizeAccountPage.authorizeAccountSwipeView.swipeToItem(AuthorizeAccountPage.AuthorizeWithCode)
             } else {
-                // At base state screen
-                if(!isNetworkConnectionAvailable) {
-                    // Goto Wifi Setup step
-                    fre.gotoNextStep(currentFreStep)
-                }
-                else if(isfirmwareUpdateAvailable) {
-                    fre.setFreStep(FreStep.SoftwareUpdate)
-                }
-                else {
-                    fre.setFreStep(FreStep.NamePrinter)
-                }
+                // For all screens not listed above, the default behavior
+                // is to go to the next step
+                fre.gotoNextStep(currentFreStep)
+            }
+        }
+    }
+
+    skipButton {
+        onClicked: {
+            if (state == "name_printer") {
+                // Skipping this step is the default 
+                inFreStep = true
+                mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
+                settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
+                settingsPage.systemSettingsPage.systemSettingsSwipeView.swipeToItem(SystemSettingsPage.ChangePrinterNamePage)
+                settingsPage.namePrinter.nameField.forceActiveFocus()
             }
         }
     }

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -10,17 +10,15 @@ LoggingItem {
     width: 800
     height: 480
     property alias continueButton: freContentRight.buttonPrimary
+    property alias skipButton: freContentRight.buttonSecondary1
 
-    Image {
-        id: bot_image
-        width: sourceSize.width
-        height: sourceSize.height
-        visible: currentFreStep == FreStep.Welcome ||
-                 currentFreStep == FreStep.SetupComplete
-        anchors.left: parent.left
-        anchors.leftMargin: 0
-        anchors.verticalCenter: parent.verticalCenter
-        source: "qrc:/img/sombrero_welcome.png"
+    ContentLeftSide {
+        id: freContentLeft
+        loadingIcon {
+            visible: true
+            icon_image: LoadingIcon.Success
+        }
+        visible: false
     }
 
     ContentRightSide {
@@ -124,14 +122,6 @@ LoggingItem {
         }
     }
 
-    FreAuthorizeWithCode {
-        id: authorizeWithCode
-        anchors.top: parent.top
-        anchors.topMargin: 40
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: currentFreStep == FreStep.LoginMbAccount
-    }
-
     property bool skipUnpacking: bot.machineType != MachineType.Magma
 
     onSkipUnpackingChanged: {
@@ -146,11 +136,6 @@ LoggingItem {
     states: [
         State {
             name: "wifi_setup"
-
-            PropertyChanges {
-                target: bot_image
-                visible: false
-            }
 
             PropertyChanges {
                 target: freContentRight.textHeader
@@ -222,11 +207,6 @@ LoggingItem {
             name: "software_update"
 
             PropertyChanges {
-                target: bot_image
-                visible: false
-            }
-
-            PropertyChanges {
                 target: freContentRight.textHeader
                 text: qsTr("PRINTER SOFTWARE UPDATE AVAILABLE")
                 anchors.topMargin: 25
@@ -273,65 +253,7 @@ LoggingItem {
             }
         },
         State {
-            name: "name_printer"
-
-            PropertyChanges {
-                target: bot_image
-                visible: false
-            }
-
-            PropertyChanges {
-                target: freContentRight.textHeader
-                text: qsTr("NAME PRINTER")
-            }
-
-            PropertyChanges {
-                target: freContentRight.textBody
-                text: qsTr("Give this printer a name to find it easier.")
-            }
-
-            PropertyChanges {
-                target: freContentRight.buttonPrimary
-                text: qsTr("CONTINUE")
-            }
-
-            PropertyChanges {
-                target: setupProgress
-                state: FreProgressItem.Active
-            }
-
-            PropertyChanges {
-                target: extrudersProgress
-                state: FreProgressItem.Disabled
-            }
-
-            PropertyChanges {
-                target: materialProgress
-                state: FreProgressItem.Disabled
-            }
-
-            PropertyChanges {
-                target: printProgress
-                state: FreProgressItem.Disabled
-            }
-
-            PropertyChanges {
-                target: connectProgress
-                state: FreProgressItem.Disabled
-            }
-
-            PropertyChanges {
-                target: progress_item
-                visible: true
-            }
-        },
-        State {
             name: "set_time_date"
-
-            PropertyChanges {
-                target: bot_image
-                visible: false
-            }
 
             PropertyChanges {
                 target: freContentRight.textHeader
@@ -380,11 +302,6 @@ LoggingItem {
         },
         State {
             name: "attach_extruders"
-
-            PropertyChanges {
-                target: bot_image
-                visible: false
-            }
 
 
             PropertyChanges {
@@ -446,11 +363,6 @@ LoggingItem {
             name: "level_build_plate"
 
             PropertyChanges {
-                target: bot_image
-                visible: false
-            }
-
-            PropertyChanges {
                 target: freContentRight.textHeader
                 text: qsTr("LEVEL BUILD PLATFORM")
             }
@@ -509,11 +421,6 @@ LoggingItem {
             name: "calibrate_extruders"
 
             PropertyChanges {
-                target: bot_image
-                visible: false
-            }
-
-            PropertyChanges {
                 target: freContentRight.textHeader
                 text: qsTr("CALIBRATE EXTRUDERS")
             }
@@ -569,11 +476,6 @@ LoggingItem {
         },
         State {
             name: "load_material"
-
-            PropertyChanges {
-                target: bot_image
-                visible: false
-            }
 
             PropertyChanges {
                 target: freContentRight.textHeader
@@ -635,11 +537,6 @@ LoggingItem {
             name: "test_print"
 
             PropertyChanges {
-                target: bot_image
-                visible: false
-            }
-
-            PropertyChanges {
                 target: freContentRight.textHeader
                 text: qsTr("READY TO PRINT")
             }
@@ -694,11 +591,27 @@ LoggingItem {
             }
         },
         State {
-            name: "log_in"
+            name: "name_printer"
 
             PropertyChanges {
-                target: bot_image
-                visible: false
+                target: freContentRight.textHeader
+                text: qsTr("PRINTER NAME:\n\n") + bot.name
+            }
+
+            PropertyChanges {
+                target: freContentRight.textBody
+                text: qsTr("You can change the printer name at any point in the system settings.")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonPrimary
+                text: qsTr("NEXT")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                text: qsTr("CHANGE PRINTER NAME")
+                visible: true
             }
 
             PropertyChanges {
@@ -742,27 +655,97 @@ LoggingItem {
             }
         },
         State {
+            name: "log_in"
+
+            PropertyChanges {
+                target: freContentRight.textHeader
+                text: qsTr("CONNECT")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonPrimary
+                text: qsTr("CONNECT ACCOUNT")
+            }
+
+            PropertyChanges {
+                target: setupProgress
+                state: FreProgressItem.Enabled
+            }
+
+            PropertyChanges {
+                target: extrudersProgress
+                state: FreProgressItem.Enabled
+            }
+
+            PropertyChanges {
+                target: materialProgress
+                state: FreProgressItem.Enabled
+            }
+
+            PropertyChanges {
+                target: printProgress
+                state: FreProgressItem.Enabled
+            }
+
+            PropertyChanges {
+                target: connectProgress
+                state: FreProgressItem.Active
+            }
+
+            PropertyChanges {
+                target: progress_item
+                visible: true
+            }
+
+            PropertyChanges {
+                target: midStep
+                position: 0.833
+            }
+
+            PropertyChanges {
+                target: endStep
+                position: 0.968
+            }
+
+            PropertyChanges {
+                target: freContentRight.textBody
+                text: qsTr("CloudPrint is a browser-based app that enables you to prepare & send files directly to your printer.\n\nCreate a MakerBot account and connect your printer to CloudPrint at:")
+            }
+
+            PropertyChanges {
+                target: freContentRight.textBody1
+                text: qsTr("cloudprint.makerbot.com")
+                visible: true
+            }
+        },
+        State {
             name: "setup_complete"
 
             PropertyChanges {
-                target: bot_image
+                target: freContentLeft
                 visible: true
             }
 
             PropertyChanges {
                 target: freContentRight.textHeader
-                text: qsTr("YOUR PRINTER IS\nSUCCESSFULLY SET UP")
+                text: qsTr("SETUP COMPLETE")
             }
 
             PropertyChanges {
                 target: freContentRight.textBody
-                text: qsTr("Log onto MakerBot CloudPrint<br>to prepare your own files for this<br>printer.")
+                text: qsTr("To learn how to prepare and send files to your printer, follow the instructions at:")
                 anchors.topMargin: 20
             }
 
             PropertyChanges {
                 target: freContentRight.buttonPrimary
-                text: qsTr("DONE")
+                text: qsTr("FINISH")
+            }
+
+            PropertyChanges {
+                target: freContentRight.textBody1
+                text: qsTr("cloudprint.makerbot.com")
+                visible: true
             }
 
             PropertyChanges {

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -37,8 +37,13 @@ ApplicationWindow {
     property bool isBuildPlateClear: bot.process.isBuildPlateClear
     property bool updatedExtruderFirmwareA: false
     property bool updatedExtruderFirmwareB: false
+
     property bool isNetworkConnectionAvailable: (bot.net.interface == "ethernet" ||
                                                  bot.net.interface == "wifi")
+    onIsNetworkConnectionAvailableChanged: {
+        fre.setStepEnable(FreStep.SetupWifi, !isNetworkConnectionAvailable)
+        fre.setStepEnable(FreStep.LoginMbAccount, isNetworkConnectionAvailable)
+    }
 
     property bool safeToRemoveUsb: bot.safeToRemoveUsb
     onSafeToRemoveUsbChanged: {
@@ -212,6 +217,7 @@ ApplicationWindow {
     property bool isfirmwareUpdateAvailable: bot.firmwareUpdateAvailable
 
     onIsfirmwareUpdateAvailableChanged: {
+        fre.setStepEnable(FreStep.SoftwareUpdate, isfirmwareUpdateAvailable)
         if(isfirmwareUpdateAvailable && isFreComplete) {
             if(settingsPage.settingsSwipeView.currentIndex != 3) {
                 firmwareUpdatePopup.open()
@@ -728,31 +734,13 @@ ApplicationWindow {
                             }
                             onClicked: {
                                 skipFreStepPopup.close()
-                                // Login step has a flow within the FRE screen unlike
-                                // other steps, so it doesnt require the skip function
-                                // like the other steps. The skip function brings the
-                                // user back to the main FRE screen, undoing the UI
-                                // navigations, resetting states etc.
-                                if(currentFreStep != FreStep.LoginMbAccount) {
-                                    currentItem.skipFreStepAction()
-                                }
+                                currentItem.skipFreStepAction()
                                 if(currentFreStep == FreStep.AttachExtruders ||
                                    currentFreStep == FreStep.LevelBuildPlate ||
                                    currentFreStep == FreStep.CalibrateExtruders ||
                                    currentFreStep == FreStep.LoadMaterial ||
                                    currentFreStep == FreStep.TestPrint) {
                                     fre.setFreStep(FreStep.FreComplete)
-                                }
-                                else if(currentFreStep == FreStep.SetupWifi) {
-                                    if(isNetworkConnectionAvailable &&
-                                       isfirmwareUpdateAvailable) {
-                                        // Go to software update step only if
-                                        // network connection is available
-                                        fre.gotoNextStep(currentFreStep)
-                                    }
-                                    else {
-                                        fre.setFreStep(FreStep.NamePrinter)
-                                    }
                                 }
                                 else {
                                     fre.gotoNextStep(currentFreStep)

--- a/src/qml/SystemSettingsPageForm.qml
+++ b/src/qml/SystemSettingsPageForm.qml
@@ -313,18 +313,7 @@ Item {
             visible: false
 
             function altBack() {
-                if(!inFreStep) {
-                    systemSettingsSwipeView.swipeToItem(SystemSettingsPage.BasePage)
-                }
-                else {
-                    skipFreStepPopup.open()
-                }
-            }
-
-            function skipFreStepAction() {
-                authorizeAccountPage.backToSettings()
-                settingsSwipeView.swipeToItem(SettingsPage.BasePage)
-                mainSwipeView.swipeToItem(MoreporkUI.BasePage)
+                systemSettingsSwipeView.swipeToItem(SystemSettingsPage.BasePage)
             }
 
             AuthorizeAccountPage {

--- a/src/qml/WiFiPageForm.qml
+++ b/src/qml/WiFiPageForm.qml
@@ -52,12 +52,7 @@ Item {
             systemSettingsSwipeView.swipeToItem(SystemSettingsPage.BasePage)
             settingsSwipeView.swipeToItem(SettingsPage.BasePage)
             mainSwipeView.swipeToItem(MoreporkUI.BasePage)
-            if(isfirmwareUpdateAvailable) {
-                fre.gotoNextStep(currentFreStep)
-            }
-            else {
-                fre.setFreStep(FreStep.NamePrinter)
-            }
+            fre.gotoNextStep(currentFreStep)
         }
     }
 


### PR DESCRIPTION
BW-5845
http://ultimaker.atlassian.net/browse/BW-5845

The name printer screen now has progressing to the next step as the default option and actually changing the machine name as the secondary option.  It also now occurs after the test print as part of "connect".

For the cloud connect step I scrapped the custom separate FRE only component and we use the same component that we use during normal operation.  We also seamlessly skip over this step if we are not connected to the internet.

The logic for skipping over the network connection and firmware update steps if they were not connected was fairly janky and directly targetted the name printer step.  So I took this opportunity to make these steps also get skipped according to the new step skipping mechanism.