### PR TITLE
FRE updates to assisted leveling

### DIFF
--- a/src/qml/AssistedLevelingForm.qml
+++ b/src/qml/AssistedLevelingForm.qml
@@ -244,6 +244,65 @@ LoggingItem {
         },
 
         State {
+            name: "fre_start_screen"
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: true
+                source: "qrc:/img/hex_key_guide.png"
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.loadingIcon
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                visible: true
+                text: qsTr("TOOLS REQUIRED")
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                visible: true
+                text: bot.machineType == MachineType.Magma ?
+                      qsTr("3mm Hex Key (included in Box 2)\n\nConfirm you have the correct key to prevent damage to screws.") :
+                      qsTr("2.5mm Hex Key (included)\n\nConfirm you have the correct key to prevent damage to screws.")
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody1
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.temperatureStatus
+                visible: false
+            }
+
+            PropertyChanges {
+                target: leveler
+                visible: false
+            }
+        },
+
+        State {
             name: "remove_build_plate"
             when: bot.process.type == ProcessType.AssistedLeveling &&
                   bot.process.stateType == ProcessStateType.BuildPlateInstructions
@@ -271,7 +330,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentRightSide.textHeader
-                text: qsTr("OPEN DOOR AND REMOVE BUILD PLATE")
+                text: qsTr("CONFIRM BUILD PLATE IS REMOVED")
                 visible: true
             }
 
@@ -288,7 +347,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentRightSide.buttonPrimary
-                text: qsTr("NEXT")
+                text: qsTr("CONFIRM")
                 visible: true
             }
 
@@ -430,7 +489,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: leveler.instructionsTitle
-                text: qsTr("LOCATE SCREWS HIGHLIGHTED IN WHITE")
+                text: qsTr("LOCATE SCREWS UNDER BUILD PLATFORM")
                 visible: true
             }
 

--- a/src/qml/BuildPlateSettingsPageForm.qml
+++ b/src/qml/BuildPlateSettingsPageForm.qml
@@ -17,6 +17,7 @@ Item {
 
     property alias buttonRaiseLowerBuildPlate: buttonRaiseLowerBuildPlate
 
+    property alias assistedLevel: assistedLevel
     property alias raiseLowerBuildPlate: raiseLowerBuildPlate
     property alias doorOpenRaiseLowerBuildPlatePopup: doorOpenRaiseLowerBuildPlatePopup
 

--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -87,6 +87,7 @@ FrePageForm {
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                 settingsPage.settingsSwipeView.swipeToItem(SettingsPage.BuildPlateSettingsPage)
                 settingsPage.buildPlateSettingsPage.buildPlateSettingsSwipeView.swipeToItem(BuildPlateSettingsPage.AssistedLevelingPage)
+                settingsPage.buildPlateSettingsPage.assistedLevel.state = "fre_start_screen"
             } else if(state == "calibrate_extruders") {
                 inFreStep = true
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
@@ -124,5 +125,11 @@ FrePageForm {
                 settingsPage.namePrinter.nameField.forceActiveFocus()
             }
         }
+    }
+
+    continueButton.help.onClicked: {
+        // Currently every help button in the FRE shows the same help
+        helpPopup.state = "fre"
+        helpPopup.open()
     }
 }

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -364,12 +364,13 @@ LoggingItem {
 
             PropertyChanges {
                 target: freContentRight.textHeader
-                text: qsTr("LEVEL BUILD PLATFORM")
+                text: qsTr("ASSISTED LEVELING")
             }
 
             PropertyChanges {
                 target: freContentRight.buttonPrimary
-                text: qsTr("CONTINUE")
+                text: qsTr("START")
+                style: ButtonRectanglePrimary.ButtonWithHelp
             }
 
             PropertyChanges {
@@ -414,7 +415,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: freContentRight.textBody
-                text: qsTr("Follow the on-screen steps to level the build plate.")
+                text: qsTr("Assisted leveling will check your build platform and prompt you to make any adjustments.")
             }
         },
         State {

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -3182,40 +3182,21 @@ ApplicationWindow {
 
                 states: [
                     State {
-                        name: "attach_extruders" // e.g.
+                        name: "fre"
 
                         PropertyChanges {
                             target: help_qr_code
-                            source: "qrc:/img/broken.png"
+                            source: "qrc:/img/fre_qr_code.png"
                         }
 
                         PropertyChanges {
                             target: help_title
-                            text: qsTr("CLOSE THE TOP LID")
+                            text: qsTr("METHOD XL SETUP GUIDE")
                         }
 
                         PropertyChanges {
                             target: help_description
-                            text: qsTr("Put the top lid back on the printer to start the print.")
-                        }
-                    },
-
-                    State {
-                        name: "load_material"  // e.g.
-
-                        PropertyChanges {
-                            target: help_qr_code
-                            source: "qrc:/img/broken.png"
-                        }
-
-                        PropertyChanges {
-                            target: help_title
-                            text: qsTr("CLOSE THE TOP LID")
-                        }
-
-                        PropertyChanges {
-                            target: help_description
-                            text: qsTr("Put the top lid back on the printer to start the print.")
+                            text: qsTr("Scan the QR code for more information and troubleshooting tips.")
                         }
                     }
                 ]

--- a/src/qml/images/assisted_level/hex_key_guide.png
+++ b/src/qml/images/assisted_level/hex_key_guide.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8b478ca82044a6a3dc5bda04bc52cb2c5e8b67656a2900b27dcac2e6cdbd89
+size 20822

--- a/src/qml/images/fre_qr_code.png
+++ b/src/qml/images/fre_qr_code.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b46bbbbbbca6148092a12fe514035533ea5a61354c5ef0344b12d365474ef73
+size 5131

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -97,6 +97,7 @@
         <file alias="leveler_indicator_blue.png">images/assisted_level/leveler_indicator_blue.png</file>
         <file alias="leveler_indicator_orange.png">images/assisted_level/leveler_indicator_orange.png</file>
         <file alias="leveling_good.png">images/assisted_level/leveling_good.png</file>
+        <file alias="hex_key_guide.png">images/assisted_level/hex_key_guide.png</file>
         <file alias="calibrate_extruders.png">images/calibration/calibrate_extruders.png</file>
         <file alias="check_nozzles_clean.png">images/clean_extruders/check_nozzles_clean.png</file>
         <file alias="scrub_nozzles.gif">images/clean_extruders/scrub_nozzles.gif</file>
@@ -222,5 +223,6 @@
         <file alias="button_help.png">images/button_help.png</file>
         <file alias="remove_upper_material.png">images/remove_upper_material.png</file>
         <file alias="remove_lower_material.png">images/remove_lower_material.png</file>
+        <file alias="fre_qr_code.png">images/fre_qr_code.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
BW-5841
http://ultimaker.atlassian.net/browse/BW-5841

Add a help popup for this step (which is the same generic fre help popup used throughout the fre) and add a separate intro screen that is just for the FRE which is a little bit clearer about which hex keys to use.

Updating the non-FRE specific behavior is a bit outside the scope of the ticket, but I did go ahead and update the text on the remove build plate and locate hex screws screens.  Replacing the image on that screen with a gif (but only making it a gif on sunflower) is much more of a pain and kind of breaks our getImageForPrinter architecture so I did not add that change to the scope of this ticket.