### PR TITLE
Add skips to FRE + step skipping bugfix

### DIFF
--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -122,12 +122,16 @@ FrePageForm {
     skipButton {
         onClicked: {
             if (state == "name_printer") {
-                // Skipping this step is the default 
+                // Skipping this step is the default
                 inFreStep = true
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                 settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
                 settingsPage.systemSettingsPage.systemSettingsSwipeView.swipeToItem(SystemSettingsPage.ChangePrinterNamePage)
                 settingsPage.namePrinter.nameField.forceActiveFocus()
+            } else {
+                // Every page that does not have custom logic for this should
+                // prompt to skip to the next step.
+                skipFreStepPopup.open()
             }
         }
     }

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -38,6 +38,10 @@ LoggingItem {
             visible: true
         }
 
+        buttonSecondary1 {
+            text: qsTr("SKIP")
+        }
+
     }
 
     Item {
@@ -224,6 +228,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
+            }
+
+            PropertyChanges {
                 target: setupProgress
                 state: FreProgressItem.Active
             }
@@ -272,6 +281,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
+            }
+
+            PropertyChanges {
                 target: setupProgress
                 state: FreProgressItem.Active
             }
@@ -313,6 +327,11 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
             }
 
             PropertyChanges {
@@ -372,6 +391,11 @@ LoggingItem {
                 target: freContentRight.buttonPrimary
                 text: qsTr("START")
                 style: ButtonRectanglePrimary.ButtonWithHelp
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
             }
 
             PropertyChanges {
@@ -491,6 +515,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
+            }
+
+            PropertyChanges {
                 target: setupProgress
                 state: FreProgressItem.Enabled
             }
@@ -550,6 +579,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
+            }
+
+            PropertyChanges {
                 target: setupProgress
                 state: FreProgressItem.Enabled
             }
@@ -605,6 +639,11 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
             }
 
             PropertyChanges {
@@ -726,6 +765,11 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONNECT ACCOUNT")
+            }
+
+            PropertyChanges {
+                target: freContentRight.buttonSecondary1
+                visible: true
             }
 
             PropertyChanges {

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -738,7 +738,9 @@ ApplicationWindow {
                             }
                             onClicked: {
                                 skipFreStepPopup.close()
-                                currentItem.skipFreStepAction()
+                                if (inFreStep) {
+                                    currentItem.skipFreStepAction()
+                                }
                                 if(currentFreStep == FreStep.AttachExtruders ||
                                    currentFreStep == FreStep.LevelBuildPlate ||
                                    currentFreStep == FreStep.CalibrateExtruders ||
@@ -3211,5 +3213,11 @@ ApplicationWindow {
                 ]
             }
         }
+    }
+
+    Component.onCompleted: {
+        fre.setStepEnable(FreStep.SetupWifi, !isNetworkConnectionAvailable)
+        fre.setStepEnable(FreStep.LoginMbAccount, isNetworkConnectionAvailable)
+        fre.setStepEnable(FreStep.SoftwareUpdate, isfirmwareUpdateAvailable)
     }
 }


### PR DESCRIPTION
BW-5854
http://ultimaker.atlassian.net/browse/BW-5854

This adds a skip button to every screen that doesn't have one.  I tried to make showing the skip button the default for every state and then only states that explicitly didn't want to show this button would override this, but for some reason every state needs to be explicit about this component being visible for it to show up.  The skip popup should really only ever need to change the step if we are invoking it from the FRE intro screen, so the callout to step specific cleanup was made conditional on having actually progressed past the intro screen.

I also noticed a bug while testing this that we are only updating the set of enabled FRE steps based on bot model properties when those properties change, and if our firmware is up to date or if we boot up offline and stay offline, these properties never actually change (in contrast, the bot type property is initialized to "unknown" so it should always fire off a change event).  So I added some code to make sure that we set FRE step enablement based on initial values once we are finished setting up the change event listeners.