### PR TITLE
Please dont run an infinite timer

### DIFF
--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -27,18 +27,12 @@ Item {
 
     Timer {
         id: secondsUpdater
-        interval: 100 // 10x per second hides time interval misses better than exactly 1x per second
+        interval: 60000
         repeat: true
-        running: true
+        running: textDateTime.visible
+        triggeredOnStart: true
         onTriggered: {
-            timeSeconds = new Date().toLocaleString(Qt.locale(), "ss")
-            // 2-on, 2-off hides time interval misses better than 1-on, 1-off
-            var newSeparatorString = (((timeSeconds % 4) < 2) ? ":" : " ")
-            if (newSeparatorString != oldSeparatorString) {
-                oldSeparatorString =  newSeparatorString
-                var formatString = "M/d  H" + oldSeparatorString + "mm"
-                textDateTime.text = new Date().toLocaleString(Qt.locale(), formatString)
-            }
+            textDateTime.text = new Date().toLocaleString(Qt.locale(), "M/d  H:mm")
         }
     }
 


### PR DESCRIPTION
I was profiling the UI on Qt creator and stumbled upon this infinite timer running at 100ms interval. It took about 120us for the callback to be serviced on my laptop. On the printer, as suspected, this took anywhere from a few ms to few tens of ms across runs. On the printer the callback was itself executed only every 120ms or so. so it was clearly bottle necked.

More importantly the feature that this is being used for-- to show the time on the top bar, isn't really to put a high precision clock on the UI, rather to make it easier to correlate events across videos and logs provided to customer support so I think we can manage comfortably with a 1 minute error margin.