### PR TITLE
Lower the build plate again after unpacking

### DIFF
--- a/src/qml/SunflowerUnpacking.qml
+++ b/src/qml/SunflowerUnpacking.qml
@@ -3,17 +3,23 @@ import QtQuick 2.10
 SunflowerUnpackingForm {
     state: "remove_box_1"
 
+    function doMove() {
+        bot.moveBuildPlate(lowering? 100 : -400, 20)
+    }
+
     continueButton.enabled: state != "raising_paused" || bot.chamberErrorCode != 48
 
     continueButton {
         onClicked: {
             if (state == "remove_box_1") {
+                lowering = false
                 state = "confirm"
-            } else if (state == "raising_paused") {
-                state = "raising"
-                bot.moveBuildPlate(-400, 20)
+            } else if (state == "move_paused") {
+                state = "moving"
+                doMove()
             } else if (state == "remove_box_2") {
-                fre.gotoNextStep(currentFreStep)
+                lowering = true
+                state = "confirm"
             }
         }
     }
@@ -21,19 +27,23 @@ SunflowerUnpackingForm {
     unpackingPopup.full_button.enabled: bot.chamberErrorCode != 48
 
     unpackingPopup.full_button.onClicked: {
-        state = "raising"
-        bot.moveBuildPlate(-400, 20)
+        state = "moving"
+        doMove()
     }
 
     unpackingPopup.left_button.onClicked: {
         unpackingPopup.close()
-        state = "remove_box_1"
+        if (lowering) {
+            state = "remove_box_2"
+        } else {
+            state = "remove_box_1"
+        }
     }
 
     unpackingPopup.right_button.onClicked: {
         if (bot.chamberErrorCode != 48 || bot.doorErrorDisabled) {
-            state = "raising"
-            bot.moveBuildPlate(-400, 20)
+            state = "moving"
+            doMove()
         } else {
             state = "close_door"
         }

--- a/src/qml/SunflowerUnpackingForm.qml
+++ b/src/qml/SunflowerUnpackingForm.qml
@@ -7,6 +7,7 @@ import ErrorTypeEnum 1.0
 LoggingItem {
     itemName: "SunflowerUnpacking"
     anchors.fill: parent
+    property bool lowering: false
     property alias continueButton: unpackingContentRightSide.buttonPrimary
     property alias unpackingPopup: unpackingPopup
 
@@ -64,11 +65,15 @@ LoggingItem {
         if (bot.process.type == ProcessType.MoveBuildPlateProcess) {
             switch(currentState) {
             case ProcessStateType.Cancelling:
-                state = "raising_paused"
+                state = "move_paused"
                 break;
             case ProcessStateType.CleaningUp:
                if (!bot.process.cancelled) {
-                   state = "remove_box_2"
+                   if (lowering) {
+                       fre.gotoNextStep(currentFreStep)
+                   } else {
+                       state = "remove_box_2"
+                   }
                }
                break;
             default:
@@ -152,11 +157,12 @@ LoggingItem {
             }
         },
         State {
-            name: "raising"
+            name: "moving"
 
             PropertyChanges {
                 target: unpackingContentRightSide.textHeader
-                text: qsTr("RAISING BUILD PLATE")
+                text: lowering? qsTr("LOWERING BUILD PLATE")
+                              : qsTr("RAISING BUILD PLATE")
                 visible: true
             }
 
@@ -182,7 +188,7 @@ LoggingItem {
             }
         },
         State {
-            name: "raising_paused"
+            name: "move_paused"
 
             PropertyChanges {
                 target: unpackingContentRightSide.textHeader


### PR DESCRIPTION
BW-5865
http://ultimaker.atlassian.net/browse/BW-5865

We don't want to just leave the build plate at the top of the chamber because it makes it hard to remove the build plate when asked to by the assisted leveling process.  Dropping the build plate 100mm gives plenty of room to get the build plate off but also takes a lot less time than dropping to the bottom.  And a user can open the door a few times and resume without hitting the bottom (we don't currently halt at the bottom endstop or track how far we dropped before the door opened).

We implement this flow by leaving all of the current states in place (with some renamings) and adding a separate state variable to differentiate between raising and lowering the build plate.