### PR TITLE
Mask long-lived popup when confirm box 1 removed

### DIFF
--- a/src/qml/SunflowerUnpackingForm.qml
+++ b/src/qml/SunflowerUnpackingForm.qml
@@ -38,6 +38,7 @@ LoggingItem {
             anchors.verticalCenterOffset: -25
 
             Image{
+                id: unpackingPopupImage
                 source: "qrc:/img/popup_error.png"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.bottomMargin: 10
@@ -165,6 +166,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: unpackingPopupImage
+                visible: false
+            }
+
+            PropertyChanges {
                 target: unpackingContentRightSide.textHeader
                 text: qsTr("RAISING BUILD PLATE")
                 visible: true
@@ -234,6 +240,11 @@ LoggingItem {
             PropertyChanges {
                 target: unpackingPopupHeader
                 text: ""
+            }
+
+            PropertyChanges {
+                target: unpackingPopupImage
+                visible: false
             }
 
             PropertyChanges {


### PR DESCRIPTION
BW-5877
http://ultimaker.atlassian.net/browse/BW-5877

A popup appears to have been granted a long life by a system that cannot close a popup until all state transition related tasks have been queued up first, which includes kicking off a process (z-stage move up) that itself instantiates its own popup.

Until we can dig deeper, we will mask the long life of this popup by hiding default strings for 2 of the states its parent will transition through before closing, so as to make it appear like the popup is being taken apart by the UI subsystem veeery slooowly.

Yes, both states need to have the headline set to the null string.