### PR TITLE
Improve material loading flow

### DIFF
--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -24,17 +24,19 @@ FrePageForm {
         printPage.printSwipeView.swipeToItem(PrintPage.StartPrintConfirm)
     }
 
-    function startFreMaterialLoad() {
+    function startFreMaterialLoad(tool_idx) {
         mainSwipeView.swipeToItem(MoreporkUI.MaterialPage)
-        materialPage.startLoadUnloadFromUI = true
         materialPage.isLoadFilament = true
-        materialPage.enableMaterialDrawer()
-        // Additional Steps for XL Material Loading Setup
-        if(materialPage.shouldSelectMaterial(0)) {
+        materialPage.toolIdx = tool_idx
+        // For Method XL the FRE additional steps screen will lead to the
+        // loading flow.
+        if(!bot.hasFilamentBay) {
             materialPage.materialSwipeView.swipeToItem(MaterialPage.FreAdditionalStepsPage)
             return
         }
-        bot.loadFilament(0, false, false)
+        materialPage.startLoadUnloadFromUI = true
+        materialPage.enableMaterialDrawer()
+        bot.loadFilament(tool_idx, false, false)
         materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadUnloadPage)
     }
 
@@ -108,7 +110,7 @@ FrePageForm {
                 settingsPage.extruderSettingsPage.extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.MaterialCaseSetup)
             } else if(state == "load_material") {
                 inFreStep = true
-                startFreMaterialLoad()
+                startFreMaterialLoad(0)
             } else if(state == "test_print") {
                 inFreStep = true
                 startTestPrint()

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -209,10 +209,10 @@ Item {
 
     enum SwipeIndex {
         BasePage,
+        FreAdditionalStepsPage,
         LoadMaterialSettingsPage,
         LoadUnloadPage,
-        AttachExtruderPage,
-        FreAdditionalStepsPage
+        AttachExtruderPage
     }
 
     LoggingSwipeView {
@@ -245,6 +245,63 @@ Item {
             }
         }
 
+        // MaterialPage.FreAdditionalStepsPage
+        Item {
+            id: freAdditionalStepsPage
+            property var backSwiper: materialSwipeView
+            property int backSwipeIndex: MaterialPage.BasePage
+            property string topBarTitle: qsTr("Load Material")
+            property bool hasAltBack: true
+            visible: false
+
+            function altBack() {
+                inFreStep = false
+                materialSwipeView.swipeToItem(MaterialPage.BasePage)
+                mainSwipeView.swipeToItem(MoreporkUI.BasePage)
+            }
+
+            ContentLeftSide {
+                visible: true
+                image {
+                    source: ("qrc:/img/methodxl_locate_desiccant.png")
+                    visible: true
+                }
+            }
+
+            ContentRightSide {
+                visible: true
+                textHeader {
+                    style: TextHeadline.Base
+                    text: qsTr("LOCATE DESICCANT IN MATERIAL BAG")
+                    visible: true
+                }
+                textBody {
+                    text: qsTr("Remove two of the desiccant pouches "+
+                               "located in your material bag.")
+                    visible: true
+                }
+                textBody1 {
+                    text: qsTr("Please note: Materials are purchased "+
+                               "and shipped separately.")
+                    font.weight: Font.Normal
+                    visible: true
+                }
+                buttonPrimary {
+                    text: qsTr("NEXT")
+                    style: ButtonRectanglePrimary.ButtonWithHelp
+                    visible: true
+                    onClicked: {
+                        materialSwipeView.swipeToItem(MaterialPage.LoadMaterialSettingsPage)
+                    }
+
+                    help.onClicked: {
+                        helpPopup.state = "locate_desiccant_help"
+                        helpPopup.open()
+                    }
+                }
+            }
+        }
+
         // MaterialPage.LoadMaterialSettingsPage
         Item {
             id: itemSelectMaterial
@@ -264,7 +321,19 @@ Item {
             id: itemLoadUnloadFilament
             property var backSwiper: materialSwipeView
             property int backSwipeIndex: MaterialPage.BasePage
-            property string topBarTitle: qsTr("Load/Unload")
+            property string topBarTitle: {
+                qsTr("%1 Material %2%3").
+                  arg(isLoadFilament ? "Load" : "Unload").
+                  arg(loadUnloadFilamentProcess.bayID).
+                  arg(bot.hasFilamentBay ?
+                      " - " + (loadUnloadFilamentProcess.bayID == 2 ? bay2 : bay1).filamentMaterialName :
+                      // The spool journal isnt updated until after the load process completes,
+                      // so we cant use the filamentMaterialName from the filament bays object.
+                      (loadUnloadFilamentProcess.bayID == 2 ? bay2 : bay1).filamentMaterialName == "UNKNOWN" ?
+                          " - " + bot.getMaterialName(loadUnloadFilamentProcess.retryMaterial) :
+                          " - " + (loadUnloadFilamentProcess.bayID == 2 ? bay2 : bay1).filamentMaterialName)
+
+            }
             property bool hasAltBack: true
             property bool backIsCancel: true
             visible: false
@@ -613,54 +682,6 @@ Item {
                     }
                 }
             ]
-        }
-
-        // MaterialPage.FreAdditionalStepsPage
-        Item {
-            id: freAdditionalStepsPage
-            property var backSwiper: materialSwipeView
-            property int backSwipeIndex: MaterialPage.BasePage
-            property string topBarTitle: qsTr("Load Material")
-
-            ContentLeftSide {
-                visible: true
-                image {
-                    source: ("qrc:/img/methodxl_locate_desiccant.png")
-                    visible: true
-                }
-            }
-            ContentRightSide {
-                visible: true
-                textHeader {
-                    style: TextHeadline.Base
-                    text: qsTr("LOCATE DESICCANT IN MATERIAL BAG")
-                    visible: true
-                }
-                textBody {
-                    text: qsTr("Remove two of the desiccant pouches "+
-                               "located in your material bag.")
-                    visible: true
-                }
-                textBody1 {
-                    text: qsTr("Please note: Materials are purchased "+
-                               "and shipped separately.")
-                    font.weight: Font.Normal
-                    visible: true
-                }
-                buttonPrimary {
-                    text: qsTr("NEXT")
-                    style: ButtonRectanglePrimary.ButtonWithHelp
-                    visible: true
-                    onClicked: {
-                        materialSwipeView.swipeToItem(MaterialPage.LoadMaterialSettingsPage)
-                    }
-
-                    help.onClicked: {
-                        helpPopup.state = "locate_desiccant_help"
-                        helpPopup.open()
-                    }
-                }
-            }
         }
     }
 

--- a/src/qml/TopBarForm.qml
+++ b/src/qml/TopBarForm.qml
@@ -195,39 +195,6 @@ Item {
                             break;
                         }
                         break;
-                    case ProcessType.Load:
-                        switch(bot.process.stateType) {
-                        case ProcessStateType.Preheating:
-                            status_text = qsTr("PREHEATING")
-                            break;
-                        case ProcessStateType.Extrusion:
-                            status_text = qsTr("EXTRUDING")
-                            break;
-                        case ProcessStateType.Stopping:
-                        case ProcessStateType.Done:
-                            status_text = qsTr("MATERIAL LOADED")
-                            break;
-                        default:
-                            status_text = qsTr("LOAD MATERIAL")
-                            break;
-                        }
-                        break;
-                    case ProcessType.Unload:
-                        switch(bot.process.stateType) {
-                        case ProcessStateType.Preheating:
-                            status_text = qsTr("PREHEATING")
-                            break;
-                        case ProcessStateType.UnloadingFilament:
-                            status_text = qsTr("UNLOADING MATERIAL")
-                            break;
-                        case ProcessStateType.Done:
-                            status_text = qsTr("MATERIAL UNLOADED")
-                            break;
-                        default:
-                            status_text = qsTr("UNLOAD MATERIAL")
-                            break;
-                        }
-                        break;
                     default:
                         status_text = qsTr("IDLE")
                         break;


### PR DESCRIPTION
BW-5886
https://ultimaker.atlassian.net/browse/BW-5886

* Fix loading flow in FRE. There is one slight weirdness in this flow. For Method flow since both the filament bays have a latch each, the support material loading starts from the close bay/latch screen, but for Method XL, since there is only one lid and latch for the material case and we don't want the user to close it at the end of model material loading the support loading flow starts from the clear excess  material screen. Yeah, I know... The caddy keeps giving.

* Material selection in the load flow during FRE is only for Method XL and not for Method/X with Labs extruder unlike outside FRE loading.

* Fix a condition on Method XL during loading when a user triggers the extruder switch and then untriggers it, the screen would go blank. It will no longer do that and promptly go back to asking then to insert filament.

* Update the top bar text to show the process name (Load/Unload), material \# ( Material 1/Material 2) and the material name during Load/Unload per the figma spec.

* Disable swap material button in the not extruding error screen during FRE. We generally want to disable anything that would take the user out of the expected FRE flow.