### PR TITLE
Restyled and hid the RETRY TEST PRINT button

### DIFF
--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -317,23 +317,17 @@ LoggingItem {
                              bot.process.stateType == ProcessStateType.Cancelled
                 }
 
-                // I dont think this button is even being used currently.
-                RoundedButton {
+
+               // Re-styled incase we want to use this in the future
+               // currently hidden because it was removed from the design
+               ButtonRectangleSecondary {
                     id: print_again_button
-                    buttonWidth: 290
-                    buttonHeight: 50
-                    label: qsTr("RETRY TEST PRINT")
-                    visible: {
-                        if(inFreStep) {
-                            bot.process.stateType == ProcessStateType.Completed ||
-                             bot.process.stateType == ProcessStateType.Failed
-                        }
-                        else {
-                            false
-                        }
-                    }
-                    button_mouseArea.onClicked: {
-                        if(!disable_button) {
+                    text: qsTr("RETRY TEST PRINT")
+                    anchors.top: acknowledgePrintFinished.bottom
+                    anchors.topMargin: bot.process.stateType == ProcessStateType.Failed ? -80 : 5
+                    visible: false
+                    onClicked: {
+                        if(print_again_button.enabled) {
                             printAgain = true
                             printPage.getPrintTimes(printPage.lastPrintTimeSec)
                             printPage.printSwipeView.swipeToItem(PrintPage.StartPrintConfirm)


### PR DESCRIPTION
BW-5896
http://ultimaker.atlassian.net/browse/BW-5896

I spoke with Praveen and instead of removing the button entirely, we are just going to hide it in case we would like to add back the functionality. As part of this I restyled the button for the completed and failed pages in the print status view. But currently this will not be visible.

Branched of ReleaseMorepork2.0 because it is a small change and I tested the print status pages are the same after this but let me know if this is incorrect to do.