### PR TITLE
Clear out the cancelling screen when we error out

### DIFF
--- a/src/qml/ExtruderSettingsPageForm.qml
+++ b/src/qml/ExtruderSettingsPageForm.qml
@@ -142,8 +142,8 @@ Item {
                 id: toolheadCalibration
                 visible: !calibrateErrorScreen.visible
                 onProcessDone: {
+                    toolheadCalibration.state = "base state"
                     if(calibrateErrorScreen.lastReportedErrorType == ErrorType.NoError) {
-                        toolheadCalibration.state = "base state"
                         extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.BasePage)
                     }
                 }


### PR DESCRIPTION
BW-5893
http://ultimaker.atlassian.net/browse/BW-5893

There appears to be specific logic to not go back to the menu when we error out of calibration.  But that logic doesn't also reset the state back to the base state, so after an error we are just left on the cancelling screen with a spinner.  We aren't really stuck since we can get back to settings with the back button and get back to the base state when we enter again, but it is pretty confusing and most users would try to wait out the spinner.