### PR TITLE
Error Screen Fixes - Chamber fan failure screen, Resume button on door/lid error screen

### DIFF
--- a/src/qml/ErrorScreenForm.qml
+++ b/src/qml/ErrorScreenForm.qml
@@ -245,7 +245,6 @@ LoggingItem {
                         }
                     }
                     visible: true
-                    enabled: !(bot.chamberErrorCode == 48 && !bot.doorErrorDisabled)
                 }
             }
         },
@@ -295,7 +294,6 @@ LoggingItem {
                         }
                     }
                     visible: true
-                    enabled: !(bot.chamberErrorCode == 45)
                 }
             }
         },


### PR DESCRIPTION
* [Clean up the error screen page;Fix chamber fan failure error screen](https://github.com/makerbot/morepork-ui/commit/901e2f2a20f0d206fcbc1bff02939e906216f828)
* [Fix resume print button prematurely enabled on the door/lid error screen](https://github.com/makerbot/morepork-ui/commit/e6099ea459bed6ab4b212b2320d3d2679109c135)