### PR TITLE
Force an update of the extruder configs when both extruders are detected

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -195,10 +195,12 @@ ApplicationWindow {
     }
 
     onExtrudersPresentChanged: {
+        // Get a fresh update of the extruders configs which will update flags
+        // used to evaluate whether the attached extruders combo is valid, as
+        // well as whether they need to be calibrated.
+        bot.getExtrudersConfigs()
         calibratePopupDeterminant()
     }
-
-    
 
     // When firmware is finished updating for an extruder, the progress doesn't
     // go to 100 and instead returns to 0. In a situation where both extruders are


### PR DESCRIPTION
The root cause of this extruder combo mismatch bug seems to be to not have the latest extruder config updates from both extruders leading to using a stale update for the first installed extruder. Since the condition for the combo mismatch check strictly looks for the approval of both the extruders, we just force an extruder config update from kaiten when both extruders are attached or when both are attached and one of them is removed.

BW-5894
https://ultimaker.atlassian.net/browse/BW-5894