### PR TITLE
Remove duplicate calibrate popup from MaterialPage

### DIFF
--- a/src/qml/MaterialPage.qml
+++ b/src/qml/MaterialPage.qml
@@ -451,9 +451,7 @@ MaterialPageForm {
 
             if (!inFreStep) {
                 if(bot.process.type == ProcessType.None) {
-                    if(bot.extruderAPresent && bot.extruderBPresent) {
-                        calibrateExtrudersPopup.open()
-                    }
+                    calibratePopupDeterminant()
                 } else if(bot.process.type == ProcessType.Print) {
                     // go to print screen
                     bot.pauseResumePrint("resume")

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -41,7 +41,6 @@ Item {
     property bool isTopLidOpen: bot.chamberErrorCode == 45
     property alias itemAttachExtruder: itemAttachExtruder
     property alias attach_extruder: attach_extruder_content
-    property alias calibrateExtrudersPopup: calibrateExtrudersPopup
 
     property alias moistureWarningPopup: moistureWarningPopup
 
@@ -683,54 +682,6 @@ Item {
                     }
                 }
             ]
-        }
-    }
-
-    CustomPopup {
-        popupName: "CalibrateExtruders"
-        id: calibrateExtrudersPopup
-        popupHeight: columnLayout_next_step.height + 130
-        showTwoButtons: true
-        visible: false
-
-        left_button_text: qsTr("SKIP")
-        left_button.onClicked: {
-            calibrateExtrudersPopup.close()
-        }
-
-        right_button_text: qsTr("GO TO PAGE")
-        right_button.onClicked: {
-            // go to calibrate screen
-            mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
-            settingsPage.settingsSwipeView.swipeToItem(SettingsPage.ExtruderSettingsPage)
-            settingsPage.extruderSettingsPage.extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.CalibrateExtrudersPage)
-            calibrateExtrudersPopup.close()
-        }
-
-        ColumnLayout {
-            id: columnLayout_next_step
-            width: 650
-            height: children.height
-            spacing: 20
-            anchors.top: parent.top
-            anchors.topMargin: 150
-            anchors.horizontalCenter: parent.horizontalCenter
-
-            TextHeadline {
-                id: headline_text
-                text: qsTr("CALIBRATE EXTRUDERS")
-                Layout.alignment: Qt.AlignHCenter
-                visible: true
-            }
-
-            TextBody {
-                text: "Calibration enables precise 3D printing. The printer must calibrate new extruders to ensure print quality"
-                Layout.preferredWidth: parent.width
-                wrapMode: Text.WordWrap
-                Layout.alignment: Qt.AlignHCenter
-                horizontalAlignment: Text.AlignHCenter
-                visible: true
-            }
         }
     }
 

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -180,6 +180,13 @@ ApplicationWindow {
             return
         }
 
+        // Do not open this popup while the user is in the process of
+        // attaching the extruders in the attach extruders flow.
+        if(materialPage.materialSwipeView.currentIndex ==
+                MaterialPage.AttachExtruderPage) {
+            return
+        }
+
         if(extrudersCalibrated || !extrudersPresent) {
             extNotCalibratedPopup.close()
         }
@@ -1878,10 +1885,11 @@ ApplicationWindow {
             }
 
             ColumnLayout {
-                width: popupContainer.width
+                width: parent.width
                 height: children.height
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenterOffset: -18
                 spacing: 10
 
                 TextHeadline {


### PR DESCRIPTION
Reuse the original popup from MoreporkUI.qml for the attach extruders flow calibration prompt as well, adding a condition that it shouldnt open while the user is in the process of attaching the extruders but only after they replace the top lid and try to go back.

BW-5906
https://ultimaker.atlassian.net/browse/BW-5906