### PR TITLE
Added remove and insert build plate gifs sunflower

### DIFF
--- a/src/qml/AssistedLevelingForm.qml
+++ b/src/qml/AssistedLevelingForm.qml
@@ -208,6 +208,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
                 target: contentLeftSide.loadingIcon
                 visible: false
             }
@@ -260,6 +265,11 @@ LoggingItem {
                 target: contentLeftSide.image
                 visible: true
                 source: "qrc:/img/hex_key_guide.png"
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
             }
 
             PropertyChanges {
@@ -319,7 +329,12 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
-                source: ("qrc:/img/%1.png").arg(getImageForPrinter("remove_build_plate"))
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                source: ("qrc:/img/%1.gif").arg(getImageForPrinter("remove_build_plate"))
                 visible: true
             }
 
@@ -380,6 +395,11 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
                 visible: false
             }
 
@@ -654,9 +674,14 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
-                visible: true
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                source: ("qrc:/img/%1.gif").arg(getImageForPrinter("insert_build_plate"))
                 anchors.leftMargin: 0
-                source: ("qrc:/img/%1.png").arg(getImageForPrinter("insert_build_plate"))
+                visible: true
             }
 
             PropertyChanges {
@@ -717,6 +742,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
                 target: contentLeftSide.loadingIcon
                 icon_image: LoadingIcon.Success
                 visible: true
@@ -766,6 +796,11 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
                 visible: false
             }
 
@@ -820,6 +855,11 @@ LoggingItem {
                 target: contentLeftSide.loadingIcon
                 icon_image: LoadingIcon.Loading
                 visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
             }
 
             PropertyChanges {

--- a/src/qml/ToolheadCalibrationForm.qml
+++ b/src/qml/ToolheadCalibrationForm.qml
@@ -102,6 +102,9 @@ LoggingItem {
                 image {
                     visible: true
                 }
+                animatedImage {
+                    visible: false
+                }
                 loadingIcon {
                     visible: false
                 }
@@ -160,6 +163,11 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
                 visible: false
             }
 
@@ -223,7 +231,12 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
-                source: ("qrc:/img/%1.png").arg(getImageForPrinter("remove_build_plate"))
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                source: ("qrc:/img/%1.gif").arg(getImageForPrinter("remove_build_plate"))
                 visible: true
             }
 
@@ -278,7 +291,17 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
-                source: ("qrc:/img/%1.png").arg(getImageForPrinter("insert_build_plate"))
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                source: ("qrc:/img/%1.gif").arg(getImageForPrinter("insert_build_plate"))
                 visible: true
             }
 
@@ -335,6 +358,11 @@ LoggingItem {
             }
 
             PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
                 target: contentLeftSide.loadingIcon
                 icon_image: LoadingIcon.Loading
                 visible: true
@@ -375,6 +403,11 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
                 visible: false
             }
 
@@ -424,6 +457,11 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
                 visible: false
             }
 

--- a/src/qml/images/assisted_level/method/insert_build_plate.gif
+++ b/src/qml/images/assisted_level/method/insert_build_plate.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47d6e2e7e2af4539af5797995ca4c7d26650b4a3c8d82e32640bd75b61de055f
+size 42892

--- a/src/qml/images/assisted_level/method/insert_build_plate.png
+++ b/src/qml/images/assisted_level/method/insert_build_plate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4028da54f9ff804f1bac35e3b975fe17bb3687051ef1946ed77d4d091ea1cdd3
-size 66213

--- a/src/qml/images/assisted_level/method/remove_build_plate.gif
+++ b/src/qml/images/assisted_level/method/remove_build_plate.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ec35a48d6513d3620ca7befae1a2c5a0903fe2c25c909507240e8022aae7f56
+size 40566

--- a/src/qml/images/assisted_level/method/remove_build_plate.png
+++ b/src/qml/images/assisted_level/method/remove_build_plate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7de1b22c30d02ef63cd800a588e6b0196257a49c482bdea341ad0779eebfc1df
-size 65049

--- a/src/qml/images/assisted_level/methodxl/insert_build_plate.gif
+++ b/src/qml/images/assisted_level/methodxl/insert_build_plate.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ff64a7bbcdbd4428f976511ca5ca7dee6a162a5e239844ab9a6ffd99c1286a7
+size 155895

--- a/src/qml/images/assisted_level/methodxl/insert_build_plate.png
+++ b/src/qml/images/assisted_level/methodxl/insert_build_plate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3d9a018b08167ccde9713c62ca3bb22f226376c933c8027d7b4d38e746f181a
-size 111375

--- a/src/qml/images/assisted_level/methodxl/remove_build_plate.gif
+++ b/src/qml/images/assisted_level/methodxl/remove_build_plate.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1165c581e8b6ea7eaad8f4f50db235cb598a7cdb8bd95767d0982f07b351f75c
+size 155466

--- a/src/qml/images/assisted_level/methodxl/remove_build_plate.png
+++ b/src/qml/images/assisted_level/methodxl/remove_build_plate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30967db5342c2b4d7de225184a3c01217da684f777d28f3d96d7b2f7aebd3955
-size 111569

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -69,8 +69,6 @@
         <file alias="icon_sombrero.png">images/icon_sombrero.png</file>
         <file alias="icon_usb.png">images/icon_usb.png</file>
         <file alias="method_assisted_level.png">images/assisted_level/method/assisted_level.png</file>
-        <file alias="method_insert_build_plate.png">images/assisted_level/method/insert_build_plate.png</file>
-        <file alias="method_remove_build_plate.png">images/assisted_level/method/remove_build_plate.png</file>
         <file alias="method_locate_screws.png">images/assisted_level/method/locate_screws.png</file>
         <file alias="method_leveler_scale.png">images/assisted_level/method/leveler_scale.png</file>
         <file alias="method_adjust_left_to_move_up_plate.png">images/assisted_level/method/adjust_left_to_move_up_plate.png</file>
@@ -79,8 +77,6 @@
         <file alias="method_adjust_right_to_move_down_plate.png">images/assisted_level/method/adjust_right_to_move_down_plate.png</file>
         <file alias="method_adjust_done.png">images/assisted_level/method/adjust_done.png</file>
         <file alias="methodxl_assisted_level.png">images/assisted_level/methodxl/assisted_level.png</file>
-        <file alias="methodxl_insert_build_plate.png">images/assisted_level/methodxl/insert_build_plate.png</file>
-        <file alias="methodxl_remove_build_plate.png">images/assisted_level/methodxl/remove_build_plate.png</file>
         <file alias="methodxl_locate_screws.png">images/assisted_level/methodxl/locate_screws.png</file>
         <file alias="methodxl_leveler_scale.png">images/assisted_level/methodxl/leveler_scale.png</file>
         <file alias="methodxl_adjust_left_to_move_up_plate.png">images/assisted_level/methodxl/adjust_left_to_move_up_plate.png</file>
@@ -228,5 +224,9 @@
         <file alias="qr_230_compatibility.png">images/qr_230_compatibility.png</file>
         <file alias="qr_230_fw_download.png">images/qr_230_fw_download.png</file>
         <file alias="qr_230_xlsetup.png">images/qr_230_xlsetup.png</file>
+        <file alias="methodxl_insert_build_plate.gif">images/assisted_level/methodxl/insert_build_plate.gif</file>
+        <file alias="methodxl_remove_build_plate.gif">images/assisted_level/methodxl/remove_build_plate.gif</file>
+        <file alias="method_insert_build_plate.gif">images/assisted_level/method/insert_build_plate.gif</file>
+        <file alias="method_remove_build_plate.gif">images/assisted_level/method/remove_build_plate.gif</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
BW-5884
http://ultimaker.atlassian.net/browse/BW-5884

We want to be more specific with insertion/removal of the build plate for Method XL. Utilizing these gifs required the use of a different component for the image, so we decided to update Method images to be gif format. So previous images are replaced with the new gifs. These are used for Calibration and Assisted Leveling based on the spec. 