### PR TITLE
Don't persist unused settings keys

### DIFF
--- a/src/settings_interface/settings_interface.cpp
+++ b/src/settings_interface/settings_interface.cpp
@@ -59,7 +59,7 @@ void SettingsInterface::writeSettings() {
 void SettingsInterface::mergeSettings(Json::Value &s1, Json::Value s2) {
     if (!s1.isObject() || !s2.isObject()) return;
     for (const auto& key : s2.getMemberNames()) {
-        if (!s1.hasMember(key)) continue;
+        if (!s1.isMember(key)) continue;
         if (s1[key].isObject()) {
             mergeSettings(s1[key], s2[key]);
         } else {


### PR DESCRIPTION
If we change the naming of settings keys, or remove settings keys, or if someone manually edits a settings key with a typo into their persisent settings, we would like to remove that unused key.  

This code change will not necessarily remove the settings key immediately, but it will eventually remove it the first time we need to write a settings change back to disk.