### PR TITLE
Change button text to say NEXT when Loading FRE

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -832,6 +832,11 @@ LoggingItem {
                 }
                 buttonPrimary {
                     style: ButtonRectanglePrimary.Button
+                    // We go through this page during FRE,
+                    // it is worth noting that when we reach
+                    // this page and are at Bay 1 we used to
+                    // check and explain the next step is to
+                    // Load Support Material to the user.
                     text: qsTr("NEXT")
                     visible: true
                 }


### PR DESCRIPTION
BW-5887
http://ultimaker.atlassian.net/browse/BW-5887

The text for the button was not fitting on the button and not reflecting the spec for FRE, so instead of "NEXT: Load Support Material" the text has been changed to just "NEXT".