### PR TITLE
Add general help state to help popup

### DIFF
--- a/src/qml/LoadUnloadFilament.qml
+++ b/src/qml/LoadUnloadFilament.qml
@@ -106,7 +106,8 @@ LoadUnloadFilamentForm {
                     helpPopup.state = "methodxl_feed_filament_help"
                     helpPopup.open()
                 } else if(state == "unloaded_filament") {
-                    helpPopup.state = "methodxl_rewind_spool_help"
+                    // Change the QR Code to be safe
+                    helpPopup.state = (inFreStep) ? "fre" : "general_help"
                     helpPopup.open()
                 }
             }

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -2858,7 +2858,7 @@ ApplicationWindow {
                         Layout.preferredHeight: children.height
                         TextHeadline {
                             id: help_title
-                            text: qsTr("METHOD COMPATIBILITY")
+                            text: qsTr("HELP")
                             Layout.alignment: Qt.AlignLeft
                             Layout.preferredWidth: parent.width
                             visible: true
@@ -2886,6 +2886,32 @@ ApplicationWindow {
                         PropertyChanges {
                             target: help_title
                             text: qsTr("METHOD XL SETUP GUIDE")
+                        }
+
+                        PropertyChanges {
+                            target: help_description
+                            text: qsTr("Scan the QR code for more information and troubleshooting tips.")
+                        }
+                    },
+
+                    State {
+                        name: "general_help"
+
+                        PropertyChanges {
+                            target: help_qr_code
+                            source: "qrc:/img/qr_230_general_help.png"
+                        }
+
+                        PropertyChanges {
+                            target: help_title
+                            text: qsTr("HELP")
+                        }
+
+                        PropertyChanges {
+                            target: help_description
+                            text: qsTr("Scan the QR code or visit the following URL "+
+                                       "for more information and troubleshooting tips."+
+                                       "<br><br><b>support.ultimaker.com</b>")
                         }
                     },
 

--- a/src/qml/images/qr_230_general_help.png
+++ b/src/qml/images/qr_230_general_help.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2a1a065da823faaf92c1e16c84d1ce4dfbdcf08932d99f4c28295bd02f724f3
+size 4266

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -228,5 +228,6 @@
         <file alias="methodxl_remove_build_plate.gif">images/assisted_level/methodxl/remove_build_plate.gif</file>
         <file alias="method_insert_build_plate.gif">images/assisted_level/method/insert_build_plate.gif</file>
         <file alias="method_remove_build_plate.gif">images/assisted_level/method/remove_build_plate.gif</file>
+        <file alias="qr_230_general_help.png">images/qr_230_general_help.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
BW-5914
http://ultimaker.atlassian.net/browse/BW-5914

We were missing a popup for the Unload material (?) screen. I added the general help popup as per the spec and connected it during unload material rewind spool page.

I am not sure if it's possible to get to the unload material page through the FRE, but I added a check, but let me know if that is incorrect. The general help qr code points to the support page. I also changed the text for the base state to say "HELP" instead of "METHOD COMPATIBILITY" as well.