### PR TITLE
Changed secondary button color on user feedback

### DIFF
--- a/src/qml/ButtonRectangleSecondaryForm.qml
+++ b/src/qml/ButtonRectangleSecondaryForm.qml
@@ -4,14 +4,15 @@ import QtQuick.Layouts 1.12
 
 ButtonRectangleBase {
     logKey: "ButtonRectangleSecondary"
-    color: "#000000"
+    color: pressed ? "#FFFFFF" : "#000000"
     border.width: 2
+
     border.color: {
         (!enabled || style == ButtonRectangleBase.ButtonDisabledHelpEnabled) ?
-                       "#808080" : (pressed ? "#B2B2B2" : "#FFFFFF")
+                       "#808080" : "#FFFFFF"
     }
     textColor: {
         (!enabled || style == ButtonRectangleBase.ButtonDisabledHelpEnabled) ?
-                   "#808080" : (pressed ? "#B2B2B2" : "#FFFFFF")
+                   "#808080" : (pressed ? "#000000" : "#FFFFFF")
     }
 }


### PR DESCRIPTION
BW-5866
http://ultimaker.atlassian.net/browse/BW-5866

Title is a little self-explanatory, but the design for feedback on secondary buttons included flashing white. 

Here is a link to the prototype (which might also be available in Jira comments) [Secondary Button Feedback Prototype](https://www.figma.com/proto/BZSIXo2FcxZ2pF9eGkr2Um/Makerbot-Design-System?type=design&node-id=4348-7846&scaling=min-zoom&page-id=3%3A40&starting-point-node-id=4348%3A7846)