### PR TITLE
Add chamber and build plate temperatures to the print file info page

### DIFF
--- a/src/qml/PrintFileInfoPageForm.qml
+++ b/src/qml/PrintFileInfoPageForm.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
+import MachineTypeEnum 1.0
 
 Item {
     anchors.fill: parent.fill
@@ -61,7 +62,22 @@ Item {
             id: extruder_temp_info
             Layout.preferredHeight: dataElement.height
             labelText: qsTr("EXTRUDER TEMP.")
-            dataText: extruder_temp.replace("+","|")
+            dataText: extruder_temp
+        }
+
+        InfoItem {
+            id: chamber_temp_info
+            Layout.preferredHeight: dataElement.height
+            labelText: qsTr("BUILD PLANE TEMP.")
+            dataText: buildplane_temp
+        }
+
+        InfoItem {
+            id: heated_build_platform_temp_info
+            Layout.preferredHeight: dataElement.height
+            labelText: qsTr("BUILD PLATFORM TEMP.")
+            dataText: buildplatform_temp
+            visible: bot.machineType == MachineType.Magma
         }
 
         InfoItem {
@@ -72,6 +88,5 @@ Item {
             // Info not available from cloudprint at the moment TODO: BW-5817
             visible: false // (startPrintSource == PrintPage.FromPrintQueue)
         }
-
     }
 }

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -28,6 +28,7 @@ Item {
     property real layer_height_mm
     property string extruder_temp
     property string buildplane_temp
+    property string buildplatform_temp
     property string slicer_name
     property string print_job_id
     property string print_token
@@ -206,9 +207,10 @@ Item {
         supportMaterialRequired = (file.extrusionMassGramsB/1000).toFixed(3)
         layer_height_mm = file.layerHeightMM.toFixed(2)
         num_shells = file.numShells
-        extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + "C" :
-                                              file.extruderTempCelciusA + "C" + " + " + file.extruderTempCelciusB + "C"
-        buildplane_temp = file.buildplaneTempCelcius + "C"
+        extruder_temp = !file.extruderUsedB ? file.extruderTempCelciusA + " °C" :
+                                              file.extruderTempCelciusA + " °C" + " | " + file.extruderTempCelciusB + " °C"
+        buildplane_temp = file.buildplaneTempCelcius + " °C"
+        buildplatform_temp = file.buildplatformTempCelcius + " °C"
         slicer_name = file.slicerName
         getPrintTimes(printTimeSec)
     }
@@ -237,8 +239,8 @@ Item {
         modelMaterialRequired = (meta['extrusion_masses_g'][0]/1000).toFixed(3)
         supportMaterialRequired = (meta['extrusion_masses_g'][1]/1000).toFixed(3)
         extruder_temp = !support_extruder_used ?
-                            meta['extruder_temperatures'][0] + "C" :
-                            meta['extruder_temperatures'][0] + "C" + " + " + meta['extruder_temperatures'][1] + "C"
+                            meta['extruder_temperatures'][0] + " °C" :
+                            meta['extruder_temperatures'][0] + " °C" + " | " + meta['extruder_temperatures'][1] + " °C"
         if("build_plane_temperature" in meta) {
             meta["buildplane_target_temperature"] = meta["build_plane_temperature"]
             delete meta["build_plane_temperature"]
@@ -250,7 +252,10 @@ Item {
                         Math.round((meta["chamber_temperature"] * 1.333) - 13) :
                         meta["chamber_temperature"]
         }
-        buildplane_temp = Math.round(meta['buildplane_target_temperature']) + "C"
+        buildplane_temp = Math.round(meta['buildplane_target_temperature']) + " °C"
+        if("platform_temperature" in meta) {
+            buildplatform_temp = meta['platform_temperature'] + " °C"
+        }
         getPrintTimes(printTimeSec)
         printQueuePopup.close()
         startPrintSource = PrintPage.FromPrintQueue

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -277,6 +277,7 @@ PrintFileInfo* MoreporkStorage::createPrintFileObject(const QFileInfo kFileInfo)
                   meta_data->extruder_temperature[1],
                   meta_data->chamber_temperature,
                   meta_data->buildplane_target_temperature,
+                  meta_data->platform_temperature,
                   meta_data->shells,
                   meta_data->layer_height,
                   meta_data->infill_density,

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -69,6 +69,7 @@ class PrintFileInfo : public QObject {
   Q_PROPERTY(int extruderTempCelciusB READ extruderTempCelciusB NOTIFY fileInfoChanged)
   Q_PROPERTY(int chamberTempCelcius READ chamberTempCelcius NOTIFY fileInfoChanged)
   Q_PROPERTY(int buildplaneTempCelcius READ buildplaneTempCelcius NOTIFY fileInfoChanged)
+  Q_PROPERTY(int buildplatformTempCelcius READ buildplatformTempCelcius NOTIFY fileInfoChanged)
   Q_PROPERTY(int numShells READ numShells NOTIFY fileInfoChanged)
   Q_PROPERTY(float layerHeightMM READ layerHeightMM NOTIFY fileInfoChanged)
   Q_PROPERTY(float infillDensity READ infillDensity NOTIFY fileInfoChanged)
@@ -85,7 +86,8 @@ class PrintFileInfo : public QObject {
   bool extruder_used_a_, extruder_used_b_;
   float extrusion_mass_grams_a_, extrusion_mass_grams_b_;
   int extruder_temp_celcius_a_, extruder_temp_celcius_b_,
-      chamber_temp_celcius_, buildplane_temp_celcius_, num_shells_;
+      chamber_temp_celcius_, buildplane_temp_celcius_,
+      buildplatform_temp_celcius_, num_shells_;
   float layer_height_mm_, infill_density_, time_estimate_sec_;
   bool uses_support_, uses_raft_;
   QString material_a_, material_b_, slicer_name_;
@@ -113,6 +115,7 @@ class PrintFileInfo : public QObject {
                   const int extruder_temp_celcius_b = 0,
                   const int chamber_temp_celcius = 0,
                   const int buildplane_temp_celcius = 0,
+                  const int buildplatform_temp_celcius = 0,
                   const int num_shells = 0,
                   const float layer_height_mm = 0.0f,
                   const float infill_density = 0.0f,
@@ -137,6 +140,7 @@ class PrintFileInfo : public QObject {
                   extruder_temp_celcius_b_(extruder_temp_celcius_b),
                   chamber_temp_celcius_(chamber_temp_celcius),
                   buildplane_temp_celcius_(buildplane_temp_celcius),
+                  buildplatform_temp_celcius_(buildplatform_temp_celcius),
                   num_shells_(num_shells),
                   layer_height_mm_(layer_height_mm),
                   infill_density_(infill_density),
@@ -161,6 +165,7 @@ class PrintFileInfo : public QObject {
         extruder_temp_celcius_b_ = rvalue.extruder_temp_celcius_b_;
         chamber_temp_celcius_ = rvalue.chamber_temp_celcius_;
         buildplane_temp_celcius_ = rvalue.buildplane_temp_celcius_;
+        buildplatform_temp_celcius_ = rvalue.buildplatform_temp_celcius_;
         num_shells_ = rvalue.num_shells_;
         layer_height_mm_ = rvalue.layer_height_mm_;
         infill_density_ = rvalue.infill_density_;
@@ -187,6 +192,7 @@ class PrintFileInfo : public QObject {
                 rvalue.extruder_temp_celcius_b_,
                 rvalue.chamber_temp_celcius_,
                 rvalue.buildplane_temp_celcius_,
+                rvalue.buildplatform_temp_celcius_,
                 rvalue.num_shells_,
                 rvalue.layer_height_mm_,
                 rvalue.infill_density_,
@@ -237,6 +243,9 @@ class PrintFileInfo : public QObject {
     }
     int buildplaneTempCelcius() const {
         return buildplane_temp_celcius_;
+    }
+    int buildplatformTempCelcius() const {
+        return buildplatform_temp_celcius_;
     }
     int numShells() const {
         return num_shells_;


### PR DESCRIPTION
This is an obvious omission in the figma spec for this page and has also been requested by Karl.

BW-5901
https://ultimaker.atlassian.net/browse/BW-5901