### PR TITLE
Support for magma top lid removal

### DIFF
--- a/src/qml/ErrorScreenForm.qml
+++ b/src/qml/ErrorScreenForm.qml
@@ -554,8 +554,9 @@ LoggingItem {
                     visible: true
                 }
                 textBody {
-                    text: qsTr("There seems to be a problem with the heaters. If this happens " +
-                               "again, please contact MakerBot support. Error %1").arg(lastReportedErrorCode)
+                    text: qsTr("There seems to be a problem with the heaters. Please make sure that " +
+                               "the top lid is securely seated. If this happens again, please " +
+                               "contact MakerBot support. Error %1").arg(lastReportedErrorCode)
                     visible: true
                 }
                 buttonPrimary {

--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -497,10 +497,7 @@ Item {
                 textBody.text: qsTr("Remove the top lid from the printer to access the carriage")
                 buttonPrimary.visible: true
                 buttonPrimary.text: qsTr("NEXT")
-                buttonPrimary.enabled: {
-                    !(bot.chamberErrorCode == 0 ||
-                     bot.chamberErrorCode == 48)
-                }
+                buttonPrimary.enabled: true
             }
 
             states: [


### PR DESCRIPTION
The main blocker here is that the attach extrders process has a step to wait for the lid to be opened, which just waits for the lid open error to be reported.  Additionally we add messaging for error 1001 for the user to check the lid.

I did not make either of these changes magma specific because they seem like good ideas in general.  There isn't any really good reason to block a first time user from skipping past the open lid step, and anyone who goes through the FRE process with extruders already attached is just needlessly slowed down by this.  And anyone who has managed to get a 1001 error for any reason should probably double check that there isn't a problem with their lid even if their switch is troggered.