### PR TITLE
Remove text wrap for print filename fix

### DIFF
--- a/src/qml/PrintModelInfoPageForm.qml
+++ b/src/qml/PrintModelInfoPageForm.qml
@@ -54,6 +54,7 @@ Item {
                     width: details_item.width
                     Layout.preferredWidth: details_item.width
                     elide: Text.ElideRight
+                    wrapMode: Text.NoWrap
                     font.weight: Font.Bold
                 }
 

--- a/src/qml/PrintStatusViewForm.qml
+++ b/src/qml/PrintStatusViewForm.qml
@@ -228,6 +228,7 @@ LoggingItem {
                         Layout.preferredWidth: parent.width - 40
                         horizontalAlignment: Text.AlignTop
                         elide: Text.ElideRight
+                        wrapMode: Text.NoWrap
                     }
 
                     // Miscellaneous subheader that is only used to display additional information


### PR DESCRIPTION
BW-5892
http://ultimaker.atlassian.net/browse/BW-5892

You can't have a text wrap and a text elide at the same time (the text wrap is prioritized) and because the text wrap was by word, we were not properly wrapping the text and it was bleeding onto the next swipe page. Text wrapping was not the intention at all, but the TextBody component includes a text wrap by the word, so this was causing it. For print status and model filename (where we would prefer the elide) it's necessary to remove the text wrap entirely. Note: This is something only happening on the printer running qt and not when it is run locally.