### PR TITLE
Remove high temp labs extruder from supported extruders list

### DIFF
--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -586,6 +586,7 @@ void KaitenBotModel::extrudersConfigsUpdate(const Json::Value &result) {
     if(supported_extruders.isArray()) { \
       QStringList extruders = {}; \
       for(const Json::Value ext : supported_extruders) { \
+        if(ext.asString() == "mk14_hot_e") continue; \
         extruders.append(getExtruderName(ext.asString().c_str())); \
       } \
       extruder ## EXT_SYM ## SupportedTypesSet(extruders); \


### PR DESCRIPTION
The high temp labs extruder is unreleased but we do support it internally at the machine level. One advantage of this is that the custom temperature list on the UI can go higher when using this extruder and the test engineering team sometimes programs extruders to this type for quick testing at higher temperatures without much hassle.

Recently in the wrong extruder popup we updated the logic to be smarter and actually show the user the supported extruders for a slot if they do happen to insert an unsupported extruder. The supported list is sent by kaiten and the UI just converts the internal extruder names to their marketing names and displays them.

Since the high temp labs extruder remains unreleased we just remove it from the supported extruder list at the UI level so the user isnt shown this extruder as a supported option but internal users can still continue using it.

BW-5919
https://ultimaker.atlassian.net/browse/BW-5919