### PR TITLE
Fixed outdated alert icon

### DIFF
--- a/src/qml/MainMenuForm.qml
+++ b/src/qml/MainMenuForm.qml
@@ -79,18 +79,7 @@ Item {
             smooth: false
             image.source: "qrc:/img/material_icon.png"
             textIconDesc.text: qsTr("MATERIAL")
-
-            Image {
-                id: no_material_warning
-                width: 30
-                height: 30
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: 75
-                anchors.right: parent.right
-                anchors.rightMargin: 35
-                source: "qrc:/img/extruder_material_error.png"
-                visible: !bot["extruderAPresent"] || !bot["extruderAFilamentPresent"]
-            }
+            alertVisible: !bot["extruderAPresent"] || !bot["extruderAFilamentPresent"]
         }
 
         MainMenuIcon {
@@ -100,18 +89,7 @@ Item {
             smooth: false
             image.source: "qrc:/img/settings_icon.png"
             textIconDesc.text: qsTr("SETTINGS")
-
-            Image {
-                id: image
-                width: sourceSize.width
-                height: sourceSize.height
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: 75
-                anchors.right: parent.right
-                anchors.rightMargin: 35
-                source: "qrc:/img/alert.png"
-                visible: isfirmwareUpdateAvailable
-            }
+            alertVisible: isfirmwareUpdateAvailable
         }
     }
 }

--- a/src/qml/MainMenuIconForm.qml
+++ b/src/qml/MainMenuIconForm.qml
@@ -11,6 +11,7 @@ Item {
     property alias imageItem: imageItem
     property alias image: image
     property alias textIconDesc: textIconDesc
+    property alias alertVisible: alert_image.visible
     property bool imageVisible: true
     property bool isDisabled: false
 
@@ -71,5 +72,17 @@ Item {
                 baseRectangle.border.color = "#00000000"
             }
         }
+    }
+
+    Image {
+        id: alert_image
+        width: 30
+        height: 30
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 75
+        anchors.right: parent.right
+        anchors.rightMargin: 35
+        source: "qrc:/img/extruder_material_error.png"
+        visible: false
     }
 }


### PR DESCRIPTION
BW-5950
http://ultimaker.atlassian.net/browse/BW-5950

I moved the alert image to the main menu icon component which should be easier to keep track. They should look the same for both icons and this image appears to only be controlled by the visibility. We want this to match and be easy to access/change in the case we add other alerts esp considering we have design goals to implement a notification system.