### PR TITLE
Protect against bad arguments for FRE steps

### DIFF
--- a/src/model/fre_tracker.cpp
+++ b/src/model/fre_tracker.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include "fre_tracker.h"
+#include "logging.h"
 
 FreTracker::FreTracker() :
     fre_tracker_path_(FRE_TRACKER_PATH),
@@ -92,12 +93,20 @@ void FreTracker::gotoNextStep(uint current_step) {
     do {
         ++current_step;
     } while (disabled_steps_.count(current_step));
+    if (current_step >= step_str_.size()) {
+        LOG(info) << "FRE step out of bounds";
+        return;
+    }
     currentFreStepSet(static_cast<FreStep>(current_step));
     next_step_ = step_str_[current_step];
     logFreStatus();
 }
 
 void FreTracker::setFreStep(uint step) {
+    if (step >= step_str_.size()) {
+        LOG(info) << "FRE step out of bounds";
+        return;
+    }
     currentFreStepSet(static_cast<FreStep>(step));
     next_step_ = step_str_[step];
     logFreStatus();


### PR DESCRIPTION
BW-5959
http://ultimaker.atlassian.net/browse/BW-5959

We should not be passing invalid step numbers to our FRE tracker or requesting that it go to the next step from the fre_complete step, but more importantly we should not segfault if we accidentally do so.  With this change any attempt to transition to an invalid step will be logged as an error but otherwise ignored.