### PR TITLE
Include QtDebug for logging fix due to build issue

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -1,4 +1,5 @@
 // Copyright MakerBot, Inc. 2022
+#include <QtDebug>
 #ifndef SRC_LOGGING_HH_
 #define SRC_LOGGING_HH_
 

--- a/src/qml/SystemSettingsPageForm.qml
+++ b/src/qml/SystemSettingsPageForm.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
 import ProcessTypeEnum 1.0
 import ProcessStateTypeEnum 1.0
+import MachineTypeEnum 1.0
 import FreStepEnum 1.0
 
 Item {


### PR DESCRIPTION
I ran into issues building develop changes in QtCreator. The issues are resolved with the change to include QtDebug in our logging.h file. 

Also noticed we have a call to the MachineType enum but are not importing the enum to the page (check for sunflower for setup procedures, no clue why this is gone/removed...)