### PR TITLE
Don't offer to delete the calibration files

### DIFF
--- a/src/qml/PrintModelInfoPageForm.qml
+++ b/src/qml/PrintModelInfoPageForm.qml
@@ -103,7 +103,7 @@ Item {
                 ButtonOptions {
                     id: moreOptionsButton
                     Layout.preferredWidth: width
-                    visible: !inFreStep
+                    visible: !inFreStep && !isInManualCalibration
                     onClicked: {
                         startPrintButton.enabled = false
                         was_pressed = true


### PR DESCRIPTION
This removes the little ... element from the calibration start print screen so that the user cannot select the "remove from printer storage" option for the calibration file.