### PR TITLE
 Handle all extruder types

### DIFF
--- a/calibration_prints/lava/mk14_c/calibration_abs-wss1_wss1.makerbot
+++ b/calibration_prints/lava/mk14_c/calibration_abs-wss1_wss1.makerbot
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca1ea7d40aa40b7ad260ee8c5db7f5487aea032545b6be85227408060f36e83c
+size 35081

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -257,6 +257,14 @@ void MoreporkStorage::getCalibrationPrint(const QString test_print_dir,
     const QString path = CAL_PRINT_PATH + test_print_dir + test_print;
     const QFileInfo kFileInfo = QFileInfo(path);
 
+    // Force this function to find a real slice, compatible or not.  For now
+    // we just assume that the test_print_name is hard coded to the one combo
+    // that we actually have support for.
+    if (!kFileInfo.exists() && test_print_dir != "mk14_c/") {
+        getCalibrationPrint("mk14_c/", test_print_name);
+        return;
+    }
+
     PrintFileInfo* current_thing = createPrintFileObject(kFileInfo);
 
     if (current_thing != nullptr) {


### PR DESCRIPTION
The basic idea here is that getCalibrationPrint will always load a valid print file, so that the calibration print intro screen can just always take the user to the start print screen with a valid print file instead of a start print screen full of garbage, and that whenever possible the calibration file chosen will be one that could actually print using the current extruders and materials.  This then allows the existing start print screen logic to tell the user that they have incompatible material loaded (though the current language on that screen is not ideal).

This was already acheived for materials because we currently only have one material combination that we currently support and we hard code that material combo instead of looking at what is actually loaded.  For extruders we acheive this by checking if we have a file matching the model extruder type, but falling back to the composite extruder type if we don't have a match.  This makes it possible to calibrate using a LABS extruder (because the printer doesn't care about extruder type mismatch if you have a LABS extruder) but gives a reasonable error message if you have a 1A extruder loaded.

This includes a "new" slice for calibration on a 1C extruder for lava, though this slice is just a copy of the 1XA slice with editted metadata.