### PR TITLE
Wait for the calibration print to actually cancel

### DIFF
--- a/src/qml/ManualCalibrationPrintFinishedForm.qml
+++ b/src/qml/ManualCalibrationPrintFinishedForm.qml
@@ -29,7 +29,6 @@ LoggingItem {
             logKey: text
             onClicked: {
                 acknowledgePrint()
-                settingsPage.extruderSettingsPage.manualZCalibration.onPrintPage = false
                 // GO BACK TO MANUAL CALIBRATION
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                 settingsPage.settingsSwipeView.swipeToItem(SettingsPage.ExtruderSettingsPage)
@@ -48,7 +47,6 @@ LoggingItem {
             logKey: text
             onClicked: {
                 acknowledgePrint()
-                settingsPage.extruderSettingsPage.manualZCalibration.onPrintPage = false
                 // PROMPT USER TO REDO AUTOCAL
                 mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                 settingsPage.settingsSwipeView.swipeToItem(SettingsPage.ExtruderSettingsPage)

--- a/src/qml/ManualZCalibrationForm.qml
+++ b/src/qml/ManualZCalibrationForm.qml
@@ -620,20 +620,13 @@ LoggingItem {
             resetManualCalValues()
             secondPass = false
 
-            // If the print process has ended
-            // you may be on the print page but
-            // not printing anything
-            if(onPrintPage) {
-                if(bot.process.type == ProcessType.Print) {
-                    // Cancel Print
-                    bot.cancel()
-                }
-                onPrintPage = false
-                printPage.acknowledgePrint()
-                printPage.clearErrors()
-                mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
-                settingsSwipeView.swipeToItem(SettingsPage.ExtruderSettingsPage)
-                extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.ManualZCalibrationPage)
+            // If we are cancelling calibration in the middle of a print, we need
+            // to make sure we exit out of the print process, which means waiting
+            // for the print to reach a terminal state, then acknowleging that state
+            if (bot.process.type == ProcessType.Print) {
+                bot.cancel();
+                waitingForCancel = true;
+                if (cancelWaitDone) completeCancelWait();
             }
 
             cancelManualZCalPopup.close()


### PR DESCRIPTION
BW-5986
http://ultimaker.atlassian.net/browse/BW-5986

When we cancel a print, we cannot immediately acknowlege the cancelled state away because we are not in the cancelled state, we are still in the cancelling state.  The easiest way around this is to not move back to the settings pages until we reach the cancelled state.

Specifically, any time that the user uses the X button in the top left corner to cancel the calibration process and a print is active, we just ask kaiten to cancel the print and set a flag to watch for when kaiten is in a state where we could acknowledge the print end state.  We account for any print end state here because we also trigger this logic when Xing out of a print that is already in any end state.

This is a little janky because you can X out of the print process multiple times while cancelling, but this doesn't actually affect anything.

I also got rid of the onPrintPage property since this was the only place that we were using it.  Hopefully this doesn't conflict too much with other tickets...