### PR TITLE
Updated popup text for mismatched material

### DIFF
--- a/src/qml/ManualCalibrationPrintFinishedForm.qml
+++ b/src/qml/ManualCalibrationPrintFinishedForm.qml
@@ -35,7 +35,7 @@ LoggingItem {
                 settingsPage.extruderSettingsPage.extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.ManualZCalibrationPage)
                 if(bot.process.stateType == ProcessStateType.Cancelled ||
                         bot.process.stateType == ProcessStateType.Failed) {
-                    settingsPage.extruderSettingsPage.manualZCalibration.state = "z_cal_start"
+                    settingsPage.extruderSettingsPage.manualZCalibration.resetProcess(false)
                 } else {
                     settingsPage.extruderSettingsPage.manualZCalibration.state = "remove_support"
                 }

--- a/src/qml/ManualZCalibration.qml
+++ b/src/qml/ManualZCalibration.qml
@@ -138,6 +138,19 @@ ManualZCalibrationForm {
         calValueItem4.value = 0.20
     }
 
+    // Reset or Restart the Manual Z Cal Process
+    // bool exit determines if we are leaving
+    // the process entirely
+    function resetProcess(exit) {
+        state = "z_cal_start"
+        resetManualCalValues()
+        secondPass = false
+        if(exit) {
+            isInManualCalibration = false
+            extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.BasePage)
+        }
+    }
+
     function back() {
         if (state == "measure") {
                 state = "remove_support"
@@ -150,11 +163,7 @@ ManualZCalibrationForm {
         } else if (state == "z_calibration") {
             state = "measure"
         } else if(state !== "updating_information") {
-            state = "z_cal_start"
-            resetManualCalValues()
-            isInManualCalibration = false
-            secondPass = false
-            extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.BasePage)
+            resetProcess(true)
         }
     }
 
@@ -188,28 +197,18 @@ ManualZCalibrationForm {
 
             // Button action in 'base state'
             bot.calibrateToolheads(["x","y"])
-            state = "z_cal_start"
-            resetManualCalValues()
-            secondPass = false
+            resetProcess(false)
         } else if (state == "success") {
-            // exit
-            state = "z_cal_start"
-            resetManualCalValues()
-            isInManualCalibration = false
-            secondPass = false
-            extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.BasePage)
+            // Exit
+            resetProcess(true)
         } else {
             state = "z_cal_qr_code"
         }
-
     }
 
     retry_button.onClicked: {
         if(state == "cal_issue") {
-            state = "z_cal_start"
-            resetManualCalValues()
-            secondPass = false
+            resetProcess(false)
         }
     }
-
 }

--- a/src/qml/ManualZCalibrationForm.qml
+++ b/src/qml/ManualZCalibrationForm.qml
@@ -634,11 +634,10 @@ LoggingItem {
             extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.BasePage)
             extruderSettingsSwipeView.swipeToItem(ExtruderSettingsPage.CalibrateExtrudersPage)
             returnToManualCal = true
-            state = "z_cal_start"
-            resetManualCalValues()
 
             // Button action in 'base state'
             bot.calibrateToolheads(["x","y"])
+            resetProcess(false)
             manual_calibration_issue_popup.close()
         }
 
@@ -683,9 +682,7 @@ LoggingItem {
         left_button_text: qsTr("STOP PROCESS")
         left_button.onClicked: {
             // Return to Start Page
-            state = "z_cal_start"
-            resetManualCalValues()
-            secondPass = false
+            resetProcess(false)
 
             // If we are cancelling calibration in the middle of a print, we need
             // to make sure we exit out of the print process, which means waiting

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -2269,6 +2269,11 @@ ApplicationWindow {
             }
             right_button.onClicked: {
                 startPrintErrorsPopup.close()
+                if(isInManualCalibration) {
+                    // Reset Manual Z Cal
+                    settingsPage.extruderSettingsPage.manualZCalibration.resetProcess(true)
+                }
+
                 resetDetailsAndGoToMaterialsPage()
             }
 
@@ -2390,15 +2395,19 @@ ApplicationWindow {
                         PropertyChanges {
                             target: sub_text_start_print_errors_popup
                             text: {
-                                (materialPage.bay1.usingExperimentalExtruder ?
-                                        qsTr("This print requires <b>%1</b> in <b>Support Extruder 2</b>.").arg(
-                                                    printPage.print_support_material_name) :
-                                  (printPage.support_extruder_used?
-                                        qsTr("This print requires <b>%1</b> in <b>Model Extruder 1</b> and <b>%2</b> in <b>Support Extruder 2</b>.").arg(
-                                                    printPage.print_model_material_name).arg(printPage.print_support_material_name) :
-                                        qsTr("This print requires <b>%1</b> in <b>Model Extruder 1</b>.").arg(
-                                                    printPage.print_model_material_name))) + "\n"
-                                qsTr("Load the correct materials to start the print or export the file again with these material settings.")
+                                if(isInManualCalibration) {
+                                    qsTr("Manual Z-Calibration print is only supported for ABS-R, ABS-CF, and RapidRinse.")
+                                } else {
+                                    (materialPage.bay1.usingExperimentalExtruder ?
+                                            qsTr("This print requires <b>%1</b> in <b>Support Extruder 2</b>.").arg(
+                                                        printPage.print_support_material_name) :
+                                      (printPage.support_extruder_used?
+                                            qsTr("This print requires <b>%1</b> in <b>Model Extruder 1</b> and <b>%2</b> in <b>Support Extruder 2</b>.").arg(
+                                                        printPage.print_model_material_name).arg(printPage.print_support_material_name) :
+                                            qsTr("This print requires <b>%1</b> in <b>Model Extruder 1</b>.").arg(
+                                                        printPage.print_model_material_name))) + "\n"
+                                    qsTr("Load the correct materials to start the print or export the file again with these material settings.")
+                                }
                             }
                         }
 


### PR DESCRIPTION
BW-5990
http://ultimaker.atlassian.net/browse/BW-5990

Updated popup for material Mismatch popup
Reset manual z cal process if user presses "change material" button Added function to reset manual z cal based on whether we exit process or not Use function instead of resetting the same variables every time.
Tested by changing the material of the spool.