### PR TITLE
Visual and usability improvements to the assisted leveling flow

### DIFF
--- a/src/qml/AssistedLevelingForm.qml
+++ b/src/qml/AssistedLevelingForm.qml
@@ -133,6 +133,7 @@ LoggingItem {
             anchors.top: image.bottom
             anchors.horizontalCenter: image.horizontalCenter
 
+            property alias baseScale: baseScale
             property alias indicatorNeedle: indicatorNeedle
             property alias levelingGoodCheckmark: levelingGoodCheckmark
 
@@ -140,7 +141,44 @@ LoggingItem {
                 id: baseScale
                 height: sourceSize.height
                 width: sourceSize.width
-                source: ("qrc:/img/%1.png").arg(getImageForPrinter("leveler_scale"))
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                source: "qrc:/img/leveler_scale.png"
+
+                Image {
+                    id: leftOutOScreenArrow
+                    height: sourceSize.height
+                    width: sourceSize.width
+                    anchors.right: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    source: "qrc:/img/leveler_indicator_out_of_screen.png"
+                }
+
+                Image {
+                    id: rightOutOfScreenArrow
+                    height: sourceSize.height
+                    width: sourceSize.width
+                    anchors.left: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    rotation: 180
+                    source: "qrc:/img/leveler_indicator_out_of_screen.png"
+                }
+
+                Rectangle {
+                    id: levelingTargetWindowLeftBounds
+                    width: 1
+                    height: parent.height
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Rectangle {
+                    id: levelingTargetWindowRightBounds
+                    width: 1
+                    height: parent.height
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                }
             }
 
             Image {
@@ -148,7 +186,7 @@ LoggingItem {
                 height: sourceSize.height
                 width: sourceSize.width
                 anchors.horizontalCenter: baseScale.horizontalCenter
-                source: "qrc:/img/leveler_indicator_orange.png"
+                source: "qrc:/img/leveler_indicator_white.png"
             }
 
             Image {
@@ -580,16 +618,45 @@ LoggingItem {
             PropertyChanges {
                 target: leveler.levelerScale.indicatorNeedle
                 anchors.horizontalCenterOffset:
-                    (targetHESLower + targetHESUpper)*0.5 - currentHES
+                    Math.min(Math.max((targetHESLower + targetHESUpper)*0.5 - currentHES, -leveler.levelerScale.baseScale.width/2), leveler.levelerScale.baseScale.width/2)
                 source: {
-                    if(currentHES <= targetHESUpper && currentHES >= targetHESLower) {
+                    // Indicator goes beyond the scale on either end - Turns orange and is capped at the ends
+                    if((((targetHESLower + targetHESUpper)*0.5 - currentHES) > leveler.levelerScale.baseScale.width/2) ||
+                       (((targetHESLower + targetHESUpper)*0.5 - currentHES) < -leveler.levelerScale.baseScale.width/2)) {
+                        "qrc:/img/leveler_indicator_orange.png"
+                    }
+                    // Indicator within the target window - Turns blue
+                    else if(currentHES <= targetHESUpper && currentHES >= targetHESLower) {
                         "qrc:/img/leveler_indicator_blue.png"
                     }
+                    // Indicator is white on other locations on the scale
                     else {
-                        "qrc:/img/leveler_indicator_orange.png"
+                        "qrc:/img/leveler_indicator_white.png"
                     }
                 }
                 visible: true
+            }
+
+            PropertyChanges {
+                target: leftOutOScreenArrow
+                visible: ((targetHESLower + targetHESUpper)*0.5 - currentHES) < -leveler.levelerScale.baseScale.width/2
+                opacity: 1 - (leveler.levelerScale.baseScale.width/2)/Math.abs((targetHESLower + targetHESUpper)*0.5 - currentHES)
+            }
+
+            PropertyChanges {
+                target: rightOutOfScreenArrow
+                visible: ((targetHESLower + targetHESUpper)*0.5 - currentHES) > leveler.levelerScale.baseScale.width/2
+                opacity: 1 - (leveler.levelerScale.baseScale.width/2)/Math.abs((targetHESLower + targetHESUpper)*0.5 - currentHES)
+            }
+
+            PropertyChanges {
+                target: levelingTargetWindowLeftBounds
+                anchors.horizontalCenterOffset: targetHESLower - ((targetHESLower + targetHESUpper)*0.5)
+            }
+
+            PropertyChanges {
+                target: levelingTargetWindowRightBounds
+                anchors.horizontalCenterOffset: targetHESUpper - ((targetHESLower + targetHESUpper)*0.5)
             }
 
             PropertyChanges {

--- a/src/qml/images/assisted_level/leveler_indicator_out_of_screen.png
+++ b/src/qml/images/assisted_level/leveler_indicator_out_of_screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad73bc3dc9bfc9ac4d44ddd24a184ea245e7cfdc04f34534a484238733f8ae83
+size 368

--- a/src/qml/images/assisted_level/leveler_indicator_white.png
+++ b/src/qml/images/assisted_level/leveler_indicator_white.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a97592a610ccedffa7657031cd03f81b511b187fc4cced30d6cbf058adb363fb
+size 148

--- a/src/qml/images/assisted_level/leveler_scale.png
+++ b/src/qml/images/assisted_level/leveler_scale.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:993bbd8b4eec0418bc0c117da4897916885d66fa5820598728cb79981cf5543c
+size 969

--- a/src/qml/images/assisted_level/method/leveler_scale.png
+++ b/src/qml/images/assisted_level/method/leveler_scale.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00828b0fc8af9069ba30224cfee2b2757f3538f4a536b3ec457a786d5186f4ad
-size 712

--- a/src/qml/images/assisted_level/methodxl/leveler_scale.png
+++ b/src/qml/images/assisted_level/methodxl/leveler_scale.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c435883930fe4e0237364e299454e0c475af0e301bf5a00fb184e34bab7a3fc6
-size 706

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -70,7 +70,6 @@
         <file alias="icon_usb.png">images/icon_usb.png</file>
         <file alias="method_assisted_level.png">images/assisted_level/method/assisted_level.png</file>
         <file alias="method_locate_screws.png">images/assisted_level/method/locate_screws.png</file>
-        <file alias="method_leveler_scale.png">images/assisted_level/method/leveler_scale.png</file>
         <file alias="method_adjust_left_to_move_up_plate.png">images/assisted_level/method/adjust_left_to_move_up_plate.png</file>
         <file alias="method_adjust_left_to_move_down_plate.png">images/assisted_level/method/adjust_left_to_move_down_plate.png</file>
         <file alias="method_adjust_right_to_move_up_plate.png">images/assisted_level/method/adjust_right_to_move_up_plate.png</file>
@@ -78,14 +77,16 @@
         <file alias="method_adjust_done.png">images/assisted_level/method/adjust_done.png</file>
         <file alias="methodxl_assisted_level.png">images/assisted_level/methodxl/assisted_level.png</file>
         <file alias="methodxl_locate_screws.png">images/assisted_level/methodxl/locate_screws.png</file>
-        <file alias="methodxl_leveler_scale.png">images/assisted_level/methodxl/leveler_scale.png</file>
         <file alias="methodxl_adjust_left_to_move_up_plate.png">images/assisted_level/methodxl/adjust_left_to_move_up_plate.png</file>
         <file alias="methodxl_adjust_left_to_move_down_plate.png">images/assisted_level/methodxl/adjust_left_to_move_down_plate.png</file>
         <file alias="methodxl_adjust_right_to_move_up_plate.png">images/assisted_level/methodxl/adjust_right_to_move_up_plate.png</file>
         <file alias="methodxl_adjust_right_to_move_down_plate.png">images/assisted_level/methodxl/adjust_right_to_move_down_plate.png</file>
         <file alias="methodxl_adjust_done.png">images/assisted_level/methodxl/adjust_done.png</file>
+        <file alias="leveler_scale.png">images/assisted_level/leveler_scale.png</file>
         <file alias="leveler_indicator_blue.png">images/assisted_level/leveler_indicator_blue.png</file>
         <file alias="leveler_indicator_orange.png">images/assisted_level/leveler_indicator_orange.png</file>
+        <file alias="leveler_indicator_white.png">images/assisted_level/leveler_indicator_white.png</file>
+        <file alias="leveler_indicator_out_of_screen.png">images/assisted_level/leveler_indicator_out_of_screen.png</file>
         <file alias="leveling_good.png">images/assisted_level/leveling_good.png</file>
         <file alias="hex_key_guide.png">images/assisted_level/hex_key_guide.png</file>
         <file alias="calibrate_extruders.png">images/calibration/calibrate_extruders.png</file>


### PR DESCRIPTION
* When one of the sides is too high or too far the leveling indicator turns orange and is capped at the edges of the screen on either side instead of going out of the screen. An arrow then indicates to the user to move in the righ direction and its brightness shows how far out of screen they are and also  whether they are moving in the right direction.

* The leveling target window between the lower and upper hes limits on either side of the midpoint hes is now actually marked on the leveling scale instaed of being marked at arbitrary positions on the previous scale which didn't didnt match the actual target window.

BW-6005
https://ultimaker.atlassian.net/browse/BW-6005