### PR TITLE
Patch to avoid segfaults on network issues

### DIFF
--- a/src/model/network.cpp
+++ b/src/model/network.cpp
@@ -47,6 +47,8 @@ void Network::authenticateWithCredentials(QString username, QString password) {
 }
 
 void Network::handleRespAuthWithCredentials() {
+    if (!m_reply) return;
+
     if (m_reply->error()) {
         LOG(info) << "Network error " << m_reply->error() << ": "
                   << m_reply->errorString().toStdString().c_str();
@@ -100,6 +102,8 @@ void Network::initiateAuthWithCode(QString printer_id,
 }
 
 void Network::handleRespInitiateAuthWithCode() {
+    if (!m_reply) return;
+
     if (m_reply->error() != QNetworkReply::NoError) {
         emit InitiateAuthWithCodeFailed();
         qWarning() << "Error No: " << m_reply->error() << "for url: " << m_reply->url().toString();
@@ -139,6 +143,8 @@ void Network::checkAuthWithCode(QString otp, QString polling_token) {
 }
 
 void Network::handleRespCheckAuthWithCode() {
+    if (!m_reply) return;
+
     if (m_reply->error() != QNetworkReply::NoError ) {
         qWarning() << "Error No: " << m_reply->error() << "for url: " << m_reply->url().toString();
         qWarning() << "Request failed, " << m_reply->errorString();


### PR DESCRIPTION
A printer exhibiting network connectivity issues was observed having a UI crash, and core dump analysis indicated that the issue was that Network::handleRespCheckAuthWithCode was invoked while m_reply was null.  This code does appear to be well written to prevent this from happening under the assumption that a QNetworkReply object can only ever fire a finished signal once.  But I also can't find any guarantee in the qt documentation that it is not possible to fire the finished signal multiple times, and it would appear that this can happen when there are network issues occurring.  So we make sure that we don't segfault when this occurs.