### PR TITLE
BW-5997-start-print-page-w-labs

### DIFF
--- a/src/qml/StartPrintMaterialViewItemForm.qml
+++ b/src/qml/StartPrintMaterialViewItemForm.qml
@@ -140,9 +140,7 @@ Item {
 
         TextSubheader {
             id: materialNameOrBayIDText
-            text: isLabsMaterial ?
-                     qsTr("LABS MATERIAL") :
-                     materialRequiredName
+            text: materialRequiredName
             font.capitalization: Font.AllUppercase
             font.weight: Font.Bold
         }
@@ -154,7 +152,7 @@ Item {
             font.weight: Font.Light
             opacity: 0.7
             visible: {
-                if(isLabsMaterial || materialMismatchCheck) {
+                if(materialMismatchCheck) {
                     false
                 } else {
                     isSpoolPresent


### PR DESCRIPTION
BW-5997
http://ultimaker.atlassian.net/browse/BW-5997

We want to see the material that a print was sliced for, so changing the text to the material required name instead of displaying "LABS MATERIAL" on the start print page. I believe this will also affect the print info page during printing, should we consider showing labs material if are on the print status view?