### PR TITLE
Fix support extruder purging in labs flow after filament jam on model labs extruder

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -38,6 +38,10 @@ ErrorScreenForm {
 
     function loadPurgeFromErrorScreen() {
         if(isExtruderAError() && (materialPage.bay1.usingExperimentalExtruder || settings.getSkipFilamentNags())) {
+            // The material selector page uses the toolIdx to show which extruder
+            // and what are the supported materials so set to the model extruder
+            // idx as that is the only labs extruder option currently.
+            materialPage.toolIdx = 0
             materialPage.isLoadFilament = true
             materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadMaterialSettingsPage)
             return;
@@ -58,6 +62,10 @@ ErrorScreenForm {
 
     function unloadFromErrorScreen() {
         if(isExtruderAError() && materialPage.bay1.usingExperimentalExtruder) {
+            // The material selector page uses the toolIdx to show which extruder
+            // and what are the supported materials so set to the model extruder
+            // idx as that is the only labs extruder option currently.
+            materialPage.toolIdx = 0
             materialPage.isLoadFilament = false
             materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadMaterialSettingsPage)
             return;


### PR DESCRIPTION
The toolIdx variable which holds the currently loading tool or the intended to be loaded tool's idx. This fixes a bug where the variable held the last loaded tool's index and used it for populating the material list when trying to clear the jam for a labs extruder in the model slot.

BW-6016
https://ultimaker.atlassian.net/browse/BW-6016