### PR TITLE
Force ContentLeftSide to be visible in all states

### DIFF
--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -567,6 +567,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -625,6 +626,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -685,6 +687,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -738,6 +741,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     source: ("qrc:/img/extrusion_%1.png").arg(bayID)
                     visible: true
@@ -802,6 +806,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -863,6 +868,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     source: ("qrc:/img/%1.png").arg(getImageForPrinter("clear_excess_material"))
                     visible: true
@@ -933,6 +939,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -1016,6 +1023,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }
@@ -1086,6 +1094,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     source: "qrc:/img/methodxl_store_material.png"
                     visible: true
@@ -1144,6 +1153,7 @@ LoggingItem {
 
             PropertyChanges {
                 target: contentLeftSide
+                visible: true
                 image {
                     visible: false
                 }


### PR DESCRIPTION
BW-6015
http://ultimaker.atlassian.net/browse/BW-6015

I don't really understand how ContentLeftSide itself would ever not be visible because we set it to be visible by default, but explicitly setting the visibility to true in every state does appear to fix the issue where this just element just disappears halfway through the flow.