### PR TITLE
FW Success Screen updated to use new template

### DIFF
--- a/src/qml/FirmwareUpdateSuccessfulScreenForm.qml
+++ b/src/qml/FirmwareUpdateSuccessfulScreenForm.qml
@@ -17,6 +17,7 @@ Item {
     }
 
     ContentLeftSide {
+        anchors.verticalCenter: parent.verticalCenter
         visible: true
         loadingIcon {
             id: update_successful_image
@@ -26,6 +27,7 @@ Item {
     }
 
     ContentRightSide {
+        anchors.verticalCenter: parent.verticalCenter
         visible: true
         textHeader {
             text: qsTr("FIRMWARE %1 SUCCESSFULLY INSTALLED").arg(bot.version)


### PR DESCRIPTION
I'm not sure if this is necessary/if anyone else noticed this but I basically remembered this and it was never updated and it seemed like a kind of low effort task to get this looking like the rest of the UI...