### PR TITLE
Dont unconditionally clear print file list  on USB drive removal

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -448,7 +448,7 @@ void MoreporkStorage::updateUsbStorageConnected(){
       QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_1).exists() ||
       QFileInfo(USB_STORAGE_DEV_BY_PATH_WITH_ACCESSORY_PORT_2).exists();
   usbStorageConnectedSet(kUsbStorConnected);
-  if (!kUsbStorConnected) {
+  if (!kUsbStorConnected && fileIsCopying()) {
       prog_copy_->cancel(); // cancel copy if one is ongoing
       printFileListReset();
   }


### PR DESCRIPTION
This fixes a bug where when viewing files saved on the printers internal storage on the UI, removing a USB drive attached to the printer will clear the file list.

There doesn't seem to be any impact on not clearing the file list on usb removal when in the 'install firwmare from USB' flow in the firwmare update page for which this was actually intended, but inadvertently also affected the print file list since both of these lists use the same list container on the c++ backend to populate the list of files to show on the UI.

BW-6024
https://ultimaker.atlassian.net/browse/BW-6024