### PR TITLE
Factory Reset Popup width wasn't being set properly

### DIFF
--- a/src/qml/SystemSettingsPageForm.qml
+++ b/src/qml/SystemSettingsPageForm.qml
@@ -1042,7 +1042,6 @@ Item {
         property bool hideButton: false
         popupHeight: factoryResetColumnLayout.height
                      + ((isResetting || hideButton) ? 90 : 145)
-        popupWidth: popupContainer.width
         visible: false
         showTwoButtons: !isResetting && !isFactoryResetDone
         showOneButton: !isResetting && isFactoryResetDone && !hideButton
@@ -1073,7 +1072,7 @@ Item {
 
         ColumnLayout {
             id: factoryResetColumnLayout
-            width: parent.width
+            width: resetToFactoryPopup.popupContainer.width
             height: children.height
             anchors.top: resetToFactoryPopup.popupContainer.top
             anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
BW-6056
http://ultimaker.atlassian.net/browse/BW-6056

I changed the width of the column layout to use the "popup container" width which allows the text wrapping to happen within the popup. 