### PR TITLE
Bw 6037 firmware update notification

### DIFF
--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -249,7 +249,7 @@ ApplicationWindow {
         if(isfirmwareUpdateAvailable && isFreComplete) {
 
             // Open FW Update popup
-            if(settingsPage.systemSettingsPage.systemSettingsSwipeView.currentIndex != 5) {
+            if(settingsPage.systemSettingsPage.systemSettingsSwipeView.currentIndex != SystemSettingsPage.FirmwareUpdatePage) {
                 firmwareUpdatePopup.open()
             }
 
@@ -262,7 +262,7 @@ ApplicationWindow {
                                            printerNotIdlePopup.open()
                                            return
                                        }
-                                       if(settingsPage.systemSettingsPage.systemSettingsSwipeView.currentIndex != 5) {
+                                       if(settingsPage.systemSettingsPage.systemSettingsSwipeView.currentIndex != SystemSettingsPage.FirmwareUpdatePage) {
                                            resetSettingsSwipeViewPages()
                                            mainSwipeView.swipeToItem(MoreporkUI.SettingsPage)
                                            settingsPage.settingsSwipeView.swipeToItem(SettingsPage.SystemSettingsPage)
@@ -270,7 +270,7 @@ ApplicationWindow {
                                        }
                                    })
 
-        } else if(!isfirmwareUpdateAvailable && isFreComplete){
+        } else if(!isfirmwareUpdateAvailable){
             removeFromNotificationsList("firmware_update_available")
         }
 


### PR DESCRIPTION
We are adding a persistent notification for firmware update to notify the user to update their printer after skipping the initial popup. The original popup should still come up when new firmware is available, we are just adding a separate notification to the top bar. When the notification is pressed the UI goes to the update firmware setting screen. The notification should be removed from the list if the variable `isfirmwareUpdateAvailable` is changed to false.