### PR TITLE
Added notification for material not detected

### DIFF
--- a/src/qml/MainMenuForm.qml
+++ b/src/qml/MainMenuForm.qml
@@ -79,9 +79,9 @@ Item {
             smooth: false
             image.source: "qrc:/img/material_icon.png"
             textIconDesc.text: qsTr("MATERIAL")
+            alertVisible: extruderMaterialAlert || materialNotPresent
 
             property bool extruderMaterialAlert: !bot["extruderAPresent"] || !bot["extruderAFilamentPresent"]
-            alertVisible: extruderMaterialAlert
             onExtruderMaterialAlertChanged: {
                 if(extruderMaterialAlert) {
                     addToNotificationsList("extruder_or_material_not_detected",
@@ -99,7 +99,8 @@ Item {
                     removeFromNotificationsList("extruder_or_material_not_detected")
                 }
             }
-            property bool materialNotPresent: !bot["extruderAFilamentPresent"] || !bot["extruderBFilamentPresent"]
+            property bool materialNotPresent: bot.loadedMaterials[0] == "unknown" ||
+                                              bot.loadedMaterials[1] == "unknown"
             onMaterialNotPresentChanged: {
                 if(materialNotPresent) {
                     addToNotificationsList("material_not_detected",


### PR DESCRIPTION
BW-6038
http://ultimaker.atlassian.net/browse/BW-6038

We are separating the check for material and extruder not detected, this is the first part. Display a persistent notification that the material is not detected and go to the material page when clicked. Remove if the material is detected.

I added the check for both extruders, the initial one was only on extruder A (filament switch), I wasn't sure which we wanted. Afaik the check wouldn't be inhibiting the use of the printer, but would just notify a user the material isn't detected, they'd be able to see which material on the material page.