### PR TITLE
Fixed incorrect icon for print file download

### DIFF
--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -988,6 +988,7 @@ Item {
 
                     PropertyChanges {
                         target: error_image
+                        source: "qrc:/img/process_error_small.png"
                         visible: true
                     }
 


### PR DESCRIPTION
BW-6076
http://ultimaker.atlassian.net/browse/BW-6076

We were initially setting the icon to be the success icon, but not changing the image later, so when the download fails we see a checkmark instead of the exclamation point. I changed this so that we see the correct image.