### PR TITLE
Fix for mid-print loading blank screen

### DIFF
--- a/src/qml/ErrorScreen.qml
+++ b/src/qml/ErrorScreen.qml
@@ -57,6 +57,8 @@ ErrorScreenForm {
         } else {
             bot.loadFilament(1, false, true)
         }
+        materialPage.materialChangeActive = true
+        materialPage.loadUnloadFilamentProcess.state = "preheating"
         materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadUnloadPage)
     }
 
@@ -79,6 +81,7 @@ ErrorScreenForm {
         } else {
             bot.unloadFilament(1, true, true)
         }
+        materialPage.materialChangeActive = true
         materialPage.loadUnloadFilamentProcess.state = "preheating"
         materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadUnloadPage)
     }


### PR DESCRIPTION
This new flag was added to prevent unnecessary state changes when the loading flow wasn't being displayed I suppose. There was also code added to set this flag when load/unload/mid-print material change began but that code was gated behind a flag named startLoadUnloadFromUI which was preventing this new flag from being set and thereby not make any assignment based state changes but still do the 'when' condition bound state changes.

The start startLoadUnloadFromUI flag is used to differentiate between load/unload started from the UI and started from other clients. There is currently no way for users to start load/unload from anywhere else other than the UI but this flag is also helps us to manually assign tool index and other data that will be relvant when moving to the loading screen instead of showing incorrect values since there is a significant delay in starting a kaiten process and updating the UI variables in time to show in the loading screens.

This also explicitly sets the loading page to the preheating state as it was showing the load/unload error screen for error 81 for a split second when trying to purge after a filament jam.