### PR TITLE
Added New Wifi Strength Icons

### DIFF
--- a/src/qml/images/wifi_low.png
+++ b/src/qml/images/wifi_low.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f07565f545dc92dd60a25fbd0a990a775ceaf2cc53adc758dd0788ba5041fc1a
+size 635

--- a/src/qml/images/wifi_medium.png
+++ b/src/qml/images/wifi_medium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20ebfe269cce056a86ba99118be15c5dcc5a7805b7e8c0fb33119d036aff83c
+size 560

--- a/src/qml/images/wifi_poor.png
+++ b/src/qml/images/wifi_poor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9662a48a88a7d2401580258e5fa96224d2995c2a4c7ea2960997cc5a28b5aca0
+size 647

--- a/src/qml/images/wifi_strong.png
+++ b/src/qml/images/wifi_strong.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b07efea8a79c89d47b2acc3a8935c44b1b0e4d43269c88b2d94ad6ec47bd65d5
+size 429

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -254,5 +254,9 @@
         <file alias="start_circle.png">images/dry_material/start_circle.png</file>
         <file alias="secure_build_plate.png">images/calibration/secure_build_plate.png</file>
         <file alias="feed_from_top.png">images/load_unload/feed_from_top.png</file>
+        <file alias="wifi_poor.png">images/wifi_poor.png</file>
+        <file alias="wifi_low.png">images/wifi_low.png</file>
+        <file alias="wifi_medium.png">images/wifi_medium.png</file>
+        <file alias="wifi_strong.png">images/wifi_strong.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
BW-6075
http://ultimaker.atlassian.net/browse/BW-6075

The old wifi strength icons were removed because they didn't look similar to the new wifi icons we have been using to show wifi connection. So new icons were made and added to use for the wifi buttons.