### PR TITLE
Remove notifications from the FRE

### DIFF
--- a/src/qml/MainMenuForm.qml
+++ b/src/qml/MainMenuForm.qml
@@ -82,8 +82,9 @@ Item {
             alertVisible: extruderMaterialAlert || materialNotPresent
 
             property bool extruderMaterialAlert: !bot["extruderAPresent"] || !bot["extruderAFilamentPresent"]
-            property bool materialNotPresent: bot.loadedMaterials[0] == "unknown" ||
-                                              bot.loadedMaterials[1] == "unknown"
+            property bool materialNotPresent: (bot.loadedMaterials[0] == "unknown" ||
+                                              bot.loadedMaterials[1] == "unknown") &&
+                                              isFreComplete
             onMaterialNotPresentChanged: {
                 if(materialNotPresent) {
                     addToNotificationsList("material_not_detected",

--- a/src/qml/MoreporkUI.qml
+++ b/src/qml/MoreporkUI.qml
@@ -121,7 +121,8 @@ ApplicationWindow {
 
 
     property bool isOffline: bot.net.interface != "wifi" &&
-                             bot.net.interface != "ethernet"
+                             bot.net.interface != "ethernet" &&
+                             isFreComplete
 
     onIsOfflineChanged: {
         if(isOffline) {


### PR DESCRIPTION
BW-6090
http://ultimaker.atlassian.net/browse/BW-6090

This hides the printer offline and material not present notifications when we are in the FRE.  It does this by making the property values that they are tied to only true when the FRE is complete, so that when we exit the FRE the notifications will automatically show up again if they should be shown.  These properties are not used anywhere else where we need to know their value during the FRE so this shouldn't affect anything other than whether we show notifications during the FRE.

I did not change the firmware update logic because there is existing logic that already hides this notification during the FRE and the property that backs the notification logic very much is used in the FRE itself.  The existing logic does technically have an issue that if a new firmware update becomes available while we are running the FRE but after the firmware update step, we won't notify the user about the new firmware, but this is a pretty small corner case.

This does not change the calibration notification because for now we just want to remove that notification.