### PR TITLE
Added backIsCancel for nozzle cleaning process

### DIFF
--- a/src/qml/ExtruderSettingsPageForm.qml
+++ b/src/qml/ExtruderSettingsPageForm.qml
@@ -121,6 +121,7 @@ Item {
             property int backSwipeIndex: ExtruderSettingsPage.BasePage
             property string topBarTitle: qsTr("Clean Extruders")
             property bool hasAltBack: true
+            property bool backIsCancel: bot.process.type == ProcessType.NozzleCleaningProcess
             smooth: false
             visible: false
 


### PR DESCRIPTION
Noticed that we aren't displaying the X (`backIsCancel`) for the Nozzle Cleaning process, but we do have an altBack procedure which opens a cancellation popup when we are in the process. I added the missing variable and set it to display an X during the process/when the cancel popup would be displayed when the back button is pressed.