### PR TITLE
Bw 6085 Added popup before automatic z-cal start

### DIFF
--- a/src/qml/CalibrationProceduresPage.qml
+++ b/src/qml/CalibrationProceduresPage.qml
@@ -248,13 +248,16 @@ Item {
 
             TextHeadline {
                 id: alert_text
-                text: qsTr("AUTOMATIC Z-ONLY CALIBRATION")
+                text: qsTr("CONFIRM BUILD PLATE CLEAR")
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
 
             TextBody {
                 id: descritpion_text
-                text: qsTr("Do you want to begin the automatic z-only calibration process?")
+                Layout.preferredWidth: autoZCalPopup.width-200
+                text: qsTr("Do you want to begin the automatic z-only calibration process?") +
+                      qsTr(" Build plate will move to begin process.")
+                horizontalAlignment: Text.AlignHCenter
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             }
         }


### PR DESCRIPTION
We have a setting to do an automatic z-only cal, and we previously were not prompting the user to actually start the process. The idea is to have a popup remind the user what they are trying to do and then begin the process when the select confirm.