### PR TITLE
Update timezones

### DIFF
--- a/src/qml/TimeZoneSelectorForm.qml
+++ b/src/qml/TimeZoneSelectorForm.qml
@@ -30,7 +30,7 @@ Item {
         {code: "CHN", name: "CHINA STANDARD TIME", GMTOffset: "GMT+8:00", path: "Asia/Shanghai"},
         {code: "JST", name: "JAPAN STANDARD TIME", GMTOffset: "GMT+9:00", path: "Asia/Tokyo"},
         {name: "AUSTRALIA"},
-        {code: "ACT", name: "AUSTRALIA CENTRAL TIME", GMTOffset: "GMT+9:30", path: "Australia/ACT"},
+        {code: "ACT", name: "AUSTRALIA CENTRAL TIME", GMTOffset: "GMT+9:30", path: "Australia/Adelaide"},
         {code: "AET", name: "AUSTRALIA EASTERN TIME", GMTOffset: "GMT+10:00", path: "Australia/Sydney"},
         {code: "NST", name: "NEW ZEALAND STANDARD TIME", GMTOffset: "GMT+12:00", path: "Pacific/Auckland"},
     ]


### PR DESCRIPTION
BW-6102
http://ultimaker.atlassian.net/browse/BW-6102

We do not use Etc/GMT for any timezone names now.  These were all wrong for some reason but also we generally want to observe DST for any timezone where most of our customers are going to be observing DST.

I left all of the US timezones alone, but for all of the other timezones I went through wikipedia and actually checked what timezone names are actually in use, so a few of the names changed here as well.  I removed a timezone for Iran because we don't sell there and also some obscure Pacific Island ones because we probably also don't have customers there and I don't want this update to take forever.

When we first released method firmware Brazil observed daylight savings time so it made sense to have separate entries for Brazil and Argentina (though of course we just used GMT offsets for these as well).  But now no South American countries use DST so we really don't need two entries. I kept Brazil since it has the highest GDP.

Also Egypt used to have a different time zone but now observes DST along with europe so I also removed that entry.  And Central Africa time wasn't even listed with the correct offset -- in reality there is almost nobody using GMT-1