### PR TITLE
Update dead makerbot.com links to ultimaker.com links

### DIFF
--- a/src/qml/FirmwareUpdatePageForm.qml
+++ b/src/qml/FirmwareUpdatePageForm.qml
@@ -53,7 +53,7 @@ LoggingItem {
     property bool updateFirmware: false
 
     function getUrlForMethod() {
-           return "makerbot.com/methodfw"
+        return "ultimaker.com/methodfw"
     }
 
     FirmwareFileListUsb {

--- a/src/qml/ReviewTestPrintPageForm.qml
+++ b/src/qml/ReviewTestPrintPageForm.qml
@@ -39,7 +39,7 @@ Item {
         }
 
         textBody1 {
-            text: "makerbot.com/calibration"
+            text: "ultimaker.com/calibration"
             font.weight: Font.Bold
             visible: true
         }


### PR DESCRIPTION
I saw another alias makerbot.com/compatibility in the material warning popups but that still seems to be active at only the makerbot site and not at ultimaker. The other two that were updated here are only accessible at the ultimaker.com domain.