### PR TITLE
Set FRE complete flag before reset in RC

### DIFF
--- a/src/qml/SystemSettingsPageForm.qml
+++ b/src/qml/SystemSettingsPageForm.qml
@@ -1050,6 +1050,9 @@ Item {
         rightButtonText: qsTr("CONFIRM")
         rightButton.onClicked: {
             isResetting = true
+            // Don't allow popups checking that we are not in FRE to
+            // display while we are doing the reset.
+            isFreComplete = false
             bot.resetToFactory(true)
             doFinalResetProceduresTimer.start()
         }


### PR DESCRIPTION
BW-6104
http://ultimaker.atlassian.net/browse/BW-6104

This fix is relatively simple and could go into the release. There is a condition where becuase the FRE step is not being changed until after the reset happens, in the case that a reset is done when the extruders need to be calibrated, the calibration determinant for the popup is triggered. By setting `isFreComplete` to false here, we ensure that a user doesn't see this before reset because the logic for the popup determinant will no longer open the popup.