### PR TITLE
Revert "Swap cloudprint ref to point to digital factory"

### DIFF
--- a/src/qml/AuthorizeAccountWithCodeForm.qml
+++ b/src/qml/AuthorizeAccountWithCodeForm.qml
@@ -52,13 +52,13 @@ Item {
             spacing: 10
             TextBody {
                 style: TextBody.Large
-                text: qsTr("Log into Digital Factory and enter the code below")
+                text: qsTr("Log into CloudPrint and enter the code below")
                 font.weight: Font.Medium
             }
 
             TextBody {
                 style: TextBody.Large
-                text: "<b>digitalfactory.ultimaker.com</b>  |  <b>" + qsTr("Add Printer > Method Series") + "</b>"
+                text: "<b>cloudprint.makerbot.com</b>  |  <b>" + qsTr("Add Printer > Method Series") + "</b>"
                 font.weight: Font.Bold
             }
         }

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -1066,13 +1066,13 @@ LoggingItem {
 
             PropertyChanges {
                 target: freContentRight.textBody
-                text: qsTr("Digital Factory is a browser-based app that enables you to prepare & send files directly to your printer.") +
-                      "\n\n" + qsTr("Create an UltiMaker account and connect your printer to Digital Factory at:")
+                text: qsTr("CloudPrint is a browser-based app that enables you to prepare & send files directly to your printer.") +
+                      "\n\n" + qsTr("Create a MakerBot account and connect your printer to CloudPrint at:")
             }
 
             PropertyChanges {
                 target: freContentRight.textBody1
-                text: "digitalfactory.ultimaker.com"
+                text: "cloudprint.makerbot.com"
 
             }
 
@@ -1147,7 +1147,7 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.textBody1
                 font.weight: Font.Bold
-                text: "digitalfactory.ultimaker.com"
+                text: qsTr("cloudprint.makerbot.com")
                 visible: true
             }
 

--- a/src/qml/PrintFileInfoPageForm.qml
+++ b/src/qml/PrintFileInfoPageForm.qml
@@ -30,7 +30,7 @@ Item {
             Layout.preferredHeight: dataElement.height
             labelText: qsTr("SUBMITTED BY")
             dataText: ""
-            // Info not available at the moment TODO: BW-5817
+            // Info not available from cloudprint at the moment TODO: BW-5817
             visible: false // (startPrintSource == PrintPage.FromPrintQueue)
         }
 
@@ -85,7 +85,7 @@ Item {
             Layout.preferredHeight: dataElement.height
             labelText: qsTr("NOTES")
             dataText: ""
-            // Info not available at the moment TODO: BW-5817
+            // Info not available from cloudprint at the moment TODO: BW-5817
             visible: false // (startPrintSource == PrintPage.FromPrintQueue)
         }
 

--- a/src/qml/PrintPageForm.qml
+++ b/src/qml/PrintPageForm.qml
@@ -385,7 +385,7 @@ Item {
                         storageThumbnailSourceSize.height: 43
                         storageThumbnail.anchors.leftMargin: 71
                         storageName: qsTr("QUEUE")
-                        storageDescription: qsTr("FROM DIGITAL FACTORY")
+                        storageDescription: qsTr("FROM CLOUDPRINT")
                         onClicked: {
                             printSwipeView.swipeToItem(PrintPage.PrintQueueBrowser)
                         }
@@ -508,7 +508,7 @@ Item {
                 TextBody {
                     style: TextBody.Large
                     font.weight: Font.Light
-                    text: qsTr("Choose another folder or export a .MakerBot file from Digital Factory.")
+                    text: qsTr("Choose another folder or export a .MakerBot file from the MakerBot Print app.")
                     anchors.top: parent.bottom
                     anchors.topMargin: 15
                     horizontalAlignment: Text.AlignHCenter
@@ -626,7 +626,7 @@ Item {
                 TextBody {
                     style: TextBody.Large
                     font.weight: Font.Light
-                    text: qsTr("Use UltiMaker Digital Factory to add to your printer's queue.")
+                    text: qsTr("Use MakerBot CloudPrint to add to your printer's queue.")
                     anchors.top: parent.bottom
                     anchors.topMargin: 15
                     horizontalAlignment: Text.AlignHCenter
@@ -1356,7 +1356,7 @@ Item {
 
             TextBody {
                 id: support_link
-                text: "support.ultimaker.com"
+                text: "support.makerbot.com"
                 horizontalAlignment: Text.AlignHCenter
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
I had github put together the branch to revert https://github.com/makerbot/morepork-ui/pull/703 but there isn't an option to specify a different target branch so this branch was develop based and not directly usable.  Still it was a single commit so it was really easy to just cherry-pick it on top of the release branch.