### PR TITLE
Disable the FRE screen primary button if a process is already running

### DIFF
--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -43,8 +43,8 @@ FrePageForm {
 
     continueButton {
         enabled: {
-            if(state != "load_material" &&
-               state != "calibrate_extruders") {
+            if(state == "load_material" ||
+               state == "calibrate_extruders") {
                 !isProcessRunning()
             }
             else {

--- a/src/qml/FrePageForm.qml
+++ b/src/qml/FrePageForm.qml
@@ -187,7 +187,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("BEGIN SETUP")
-
             }
 
             PropertyChanges {
@@ -262,7 +261,6 @@ LoggingItem {
                         qsTr("CONNECT TO NETWORK")
                     }
                 }
-                enabled: true
             }
 
             PropertyChanges {
@@ -331,7 +329,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
-                enabled: true
             }
 
             PropertyChanges {
@@ -396,7 +393,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
-                enabled: true
             }
 
             PropertyChanges {
@@ -462,7 +458,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("START")
-                enabled: true
                 style: (bot.machineType == MachineType.Magma) ? ButtonRectangleBaseForm.ButtonWithHelp : ButtonRectangleBaseForm.Button
             }
 
@@ -525,7 +520,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("START")
-                enabled: true
                 style: (bot.machineType == MachineType.Magma) ? ButtonRectangleBaseForm.ButtonWithHelp : ButtonRectangleBaseForm.Button
             }
 
@@ -608,7 +602,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("START")
-                enabled: true
                 style: (bot.machineType == MachineType.Magma) ? ButtonRectangleBaseForm.ButtonWithHelp : ButtonRectangleBaseForm.Button
             }
 
@@ -618,7 +611,6 @@ LoggingItem {
                 enabled: true
                 Layout.preferredWidth: freContentRight.buttonPrimary.width
             }
-
 
             PropertyChanges {
                 target: setupProgress
@@ -676,7 +668,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("START")
-                enabled: true
                 style: (bot.machineType == MachineType.Magma) ? ButtonRectangleBaseForm.ButtonWithHelp : ButtonRectangleBaseForm.Button
             }
 
@@ -754,7 +745,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
-                enabled: true
                 style: (bot.machineType == MachineType.Magma) ? ButtonRectangleBaseForm.ButtonWithHelp : ButtonRectangleBaseForm.Button
             }
 
@@ -831,7 +821,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONTINUE")
-                enabled: true
             }
 
             PropertyChanges {
@@ -905,7 +894,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("NEXT")
-                enabled: true
             }
 
             PropertyChanges {
@@ -1061,7 +1049,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("CONNECT ACCOUNT")
-                enabled: true
             }
 
             PropertyChanges {
@@ -1154,7 +1141,6 @@ LoggingItem {
             PropertyChanges {
                 target: freContentRight.buttonPrimary
                 text: qsTr("FINISH")
-                enabled: true
             }
 
             PropertyChanges {


### PR DESCRIPTION
This seems to have been accidentally modified during the FRE redesign work before launch. The secondary button also has hardcoded enabled attribute but it does not have any other explicit conditional logic to control its enabled property elsewhere like the primary button.

This is also only applicable when in the calibrate and load material step of the FRE. This was the earlier behavior and I left it as is.

BW-6113
https://ultimaker.atlassian.net/browse/BW-6113