### PR TITLE
In FRE, only allow material combos for which we have test prints

### DIFF
--- a/src/qml/MaterialPageForm.qml
+++ b/src/qml/MaterialPageForm.qml
@@ -308,8 +308,22 @@ Item {
             property var backSwiper: materialSwipeView
             property int backSwipeIndex: MaterialPage.BasePage
             property string topBarTitle: qsTr("Select Material")
+            property bool hasAltBack: true
             visible: false
 
+            function altBack() {
+                if(!inFreStep) {
+                    leaveMaterialChange()
+                }
+                else {
+                    skipFreStepPopup.open()
+                }
+            }
+
+            function skipFreStepAction() {
+                materialSwipeView.swipeToItem(MaterialPage.BasePage)
+                mainSwipeView.swipeToItem(MoreporkUI.BasePage)
+            }
 
             LoadMaterialSettings {
                 id: loadMaterialSettingsPage

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -238,6 +238,14 @@ void MoreporkStorage::updateFirmwareFileList(const QString directory_path) {
   }
 }
 
+QStringList MoreporkStorage::getAvailableTestPrints(const QString test_print_dir) {
+    const QDir path(TEST_PRINT_PATH + test_print_dir);
+    QStringList filters;
+    filters << "*.makerbot";
+    QStringList files(path.entryList(filters));
+    return files;
+}
+
 void MoreporkStorage::getTestPrint(const QString test_print_dir,
                                    const QString test_print_name) {
     const QString test_print = TEST_PRINT_FILE_PREFIX + test_print_name + ".makerbot";

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -366,6 +366,7 @@ class MoreporkStorage : public QObject {
                                   const QString test_print_name);
     Q_INVOKABLE void getCalibrationPrint(const QString test_print_dir,
                                          const QString test_print_name);
+    Q_INVOKABLE QStringList getAvailableTestPrints(const QString test_print_dir);
 
   private:
     QFileSystemWatcher *storage_watcher_, *usb_storage_watcher_, *last_thing_watcher_;


### PR DESCRIPTION
When loading the support material in FRE, filter material options to only the ones where there exists a test print with the loaded model material

Also add an altBack function during material selection to properly exit out of the FRE (previously it would take you to the Materials page but not have exited the FRE cleanly, eg. inFreStep would still be set)