### PR TITLE
Don't try to request ext stats immediately on new ext attached

### DIFF
--- a/src/qml/ExtruderInfoContents.qml
+++ b/src/qml/ExtruderInfoContents.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.10
 
 ExtruderInfoContentsForm {
-    onExtruderPresentChanged: {
-        if (extruderPresent) {
+    onExtPresentAndVisibleChanged: {
+        if (extPresentAndVisible) {
             bot.getToolStats(toolIdx);
         }
     }

--- a/src/qml/ExtruderInfoContentsForm.qml
+++ b/src/qml/ExtruderInfoContentsForm.qml
@@ -13,6 +13,7 @@ Item {
     property bool extruderPresent: false
     property bool statsReady: false
 
+    property bool extPresentAndVisible: extruderPresent && visible
     property bool showStats: extruderPresent && statsReady
 
     width: 350


### PR DESCRIPTION
Seems something isn't right with how waiting for extruder stats is being handled in kaiten so system notifications are not making it to the UI? if extruder stats are requested while machine is still reading them in... which is pretty sketchy, and was resulting in the UI not updating attached/detached state in a timely manner (and probably some other issues as well...)

So make ExtruderInfoContents request extruder stats only if it is visible. In the common case, machine would have already loaded extruder stats in the background and kaiten wouldn't have to wait for them when requested. We would still see the UI not updating info properly (for up to about a min) if we opened the extruder info page too soon after an extruder is newly attached, or were already opened to it on extruder attaching, which is still not _great_ but hopefully okay enough to not cause any _noticible_ issues...