### PR TITLE
Allow user to manually select load filament type on Method/Method X

### DIFF
--- a/src/model/bot_model.cpp
+++ b/src/model/bot_model.cpp
@@ -219,8 +219,12 @@ void BotModel::changeMachineName(QString new_name) {
     qDebug() << FL_STRM << "called with parameters: " << new_name;
 }
 
-void BotModel::acknowledgeMaterial(bool response) {
-    qDebug() << FL_STRM << "called with parameters: " << response;
+void BotModel::acknowledgeMaterial(QList<int> temperature, QString material) {
+    qDebug() << FL_STRM << "called with  material: " << material;
+    qDebug() << "temperatures: ";
+    for(int i = 0; i < temperature.size(); i++) {
+        qDebug() << temperature.value(i);
+    }
 }
 
 void BotModel::acknowledgeSafeToRemoveUsb() {

--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -84,7 +84,8 @@ class BotModel : public BaseModel {
     Q_INVOKABLE virtual void zipTimelapseImages(QString path);
     Q_INVOKABLE virtual void forceSyncFile(QString path);
     Q_INVOKABLE virtual void changeMachineName(QString new_name);
-    Q_INVOKABLE virtual void acknowledgeMaterial(bool response);
+    Q_INVOKABLE virtual void acknowledgeMaterial(
+            QList<int> temperature = {0,0}, QString material="None");
     Q_INVOKABLE virtual void acknowledgeSafeToRemoveUsb();
     Q_INVOKABLE virtual void getSystemTime();
     Q_INVOKABLE virtual void setSystemTime(QString new_time);

--- a/src/qml/FilamentBayForm.qml
+++ b/src/qml/FilamentBayForm.qml
@@ -74,18 +74,18 @@ Item {
     }
 
     property string filamentMaterialName: {
-        if (bot.hasFilamentBay) {
-            bot["spool%1MaterialName".arg(idxAsAxis)]
-        } else {
+        if (!bot.hasFilamentBay || bot.loadedMaterialNames[filamentBayID - 1] != 'UNKNOWN') {
             bot.loadedMaterialNames[filamentBayID - 1]
+        } else {
+            bot['spool%1MaterialName'.arg(idxAsAxis)]
         }
     }
 
     property string filamentMaterial: {
-        if (bot.hasFilamentBay) {
-            bot["spool%1Material".arg(idxAsAxis)]
-        } else {
+        if (!bot.hasFilamentBay || bot.loadedMaterials[filamentBayID - 1] != 'unknown') {
             bot.loadedMaterials[filamentBayID - 1]
+        } else {
+            bot['spool%1Material'.arg(idxAsAxis)]
         }
     }
 
@@ -164,6 +164,7 @@ Item {
     property bool spoolDetailsReady: bot["spool%1DetailsReady".arg(idxAsAxis)]
     property bool spoolPresent: bot["filamentBay%1TagPresent".arg(idxAsAxis)]
     property bool extruderFilamentPresent: bot["extruder%1FilamentPresent".arg(idxAsAxis)]
+    property bool bayFilamentPresent: bot["filamentBay%1FilamentPresent".arg(idxAsAxis)]
     property string filamentColorName: bot["spool%1ColorName".arg(idxAsAxis)]
     property real filamentLength: bot["spool%1AmountRemaining".arg(idxAsAxis)]/10
     // convert length from cm to mm, convert linear density from g/mm to kg/mm, multiply to yield mass in kg

--- a/src/qml/FrePage.qml
+++ b/src/qml/FrePage.qml
@@ -26,19 +26,14 @@ FrePageForm {
 
     function startFreMaterialLoad(tool_idx) {
         mainSwipeView.swipeToItem(MoreporkUI.MaterialPage)
-        materialPage.isLoadFilament = true
-        materialPage.toolIdx = tool_idx
-        materialPage.startLoadUnloadFromUI = true
-        materialPage.materialChangeActive = true
         // For Method XL the FRE additional steps screen will lead to the
         // loading flow.
         if(!bot.hasFilamentBay) {
             materialPage.materialSwipeView.swipeToItem(MaterialPage.FreAdditionalStepsPage)
             return
         }
-        materialPage.enableMaterialDrawer()
+        materialPage.loadSetup(tool_idx)
         bot.loadFilament(tool_idx, false, false)
-        materialPage.materialSwipeView.swipeToItem(MaterialPage.LoadUnloadPage)
     }
 
     continueButton {

--- a/src/qml/LoadMaterialSettingsForm.qml
+++ b/src/qml/LoadMaterialSettingsForm.qml
@@ -29,11 +29,10 @@ Item {
             materialSwipeView.swipeToItem(MaterialPage.BasePage)
             return;
         }
-        var external = isLoadFilament ? false : true
         if(isLoadFilament) {
-            load(tool_idx, external, temperature)
+            load(tool_idx, false, temperature)
         } else {
-            unload(tool_idx, external, temperature)
+            unload(tool_idx, true, temperature)
         }
         selectMaterialSwipeView.swipeToItem(LoadMaterialSettings.SelectMaterialPage)
     }

--- a/src/qml/LoadUnloadFilament.qml
+++ b/src/qml/LoadUnloadFilament.qml
@@ -173,4 +173,10 @@ LoadUnloadFilamentForm {
                 temperature_list, retryMaterial);
         }
     }
+
+    function reset() {
+        retryTemperature = 0
+        retryMaterial = "None"
+        retryExternal = false
+    }
 }

--- a/src/qml/LoadUnloadFilamentForm.qml
+++ b/src/qml/LoadUnloadFilamentForm.qml
@@ -24,6 +24,8 @@ LoggingItem {
     property bool retryExternal: false
     property int bayID: 0
     property int currentActiveTool: bot.process.currentToolIndex + 1
+
+
     // Hold onto the current bay ID even after the process completes
     onCurrentActiveToolChanged: {
         if(currentActiveTool > 0) {
@@ -75,7 +77,8 @@ LoggingItem {
         if(bot.process.type == ProcessType.Load) {
             if(isSpoolDetailsReady) {
                 if(materialValidityCheck()) {
-                    bot.acknowledgeMaterial(true)
+                    console.info("ack here")
+                    bot.acknowledgeMaterial()
                     // Check for moisture alert anytime a valid
                     // material is placed on the bay when loading.
                     maybeShowMoistureWarningPopup(bayID)

--- a/src/qml/MaterialIconForm.qml
+++ b/src/qml/MaterialIconForm.qml
@@ -21,6 +21,15 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
     }
 
+    TextBody {
+        id: warning
+        text: qsTr("!")
+        style: TextBody.Large
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        horizontalAlignment: Text.AlignHCenter
+    }
+
     Item {
         id: material_status_icon
         anchors.fill: parent
@@ -114,6 +123,11 @@ Item {
             }
 
             PropertyChanges {
+                target: warning
+                visible: false
+            }
+
+            PropertyChanges {
                 target: material_status_icon
                 visible: false
             }
@@ -134,6 +148,11 @@ Item {
 
             PropertyChanges {
                 target: error_image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: warning
                 visible: false
             }
 
@@ -159,6 +178,11 @@ Item {
             PropertyChanges {
                 target: error_image
                 visible: false
+            }
+
+            PropertyChanges {
+                target: warning
+                visible: bayFilamentPresent && !usingExperimentalExtruder
             }
 
             PropertyChanges {

--- a/src/qml/MaterialStatusForm.qml
+++ b/src/qml/MaterialStatusForm.qml
@@ -6,22 +6,27 @@ import ProcessStateTypeEnum 1.0
 import MachineTypeEnum 1.0
 
 Item {
+
     id: materialStatusForm
     width: 344
     height: 100
 
     RowLayout {
         id: contentContainer
+        width: parent.width
         spacing: 32
 
         MaterialIcon {
             id: materialIcon
             smooth: false
             antialiasing: false
+            Layout.alignment: Qt.AlignTop
         }
 
-        ColumnLayout {
+        Column {
             spacing: 4
+            Layout.fillWidth: true
+
             TextSubheader {
                 text: qsTr("MATERIAL %1").arg(filamentBayID)
             }
@@ -30,6 +35,8 @@ Item {
                 id: materialText
                 style: TextBody.ExtraLarge
                 font.weight: Font.Bold
+                width: parent.width
+
                 text: {
                     // Print paused and extruder switch not triggered. This condition is the LCD
                     // for all types of printers where we want to prompt the user to load a specific
@@ -39,13 +46,13 @@ Item {
                         qsTr("LOAD %1").arg(printMaterialName)
                     }
                     // Printers with Filament Bay (Method/X)
-                    else if(bot.hasFilamentBay && spoolPresent && !isUnknownMaterial) {
+                    else if(bot.hasFilamentBay && filamentMaterial != 'unknown') {
                         filamentMaterialName.toUpperCase()
                     }
                     // Printers without Filament Bay (Method XL) or ones using a labs extruder
                     else if((!bot.hasFilamentBay || usingExperimentalExtruder) &&
                               (bot.loadedMaterials[filamentBayID - 1] != "unknown")) {
-                        bot.loadedMaterialNames[filamentBayID - 1].toUpperCase()
+                        filamentMaterialName.toUpperCase()
                     } else if(usingExperimentalExtruder && extruderFilamentPresent) {
                         qsTr("LABS MATERIAL\nLOADED")
                     } else {
@@ -54,9 +61,9 @@ Item {
                 }
             }
 
-            ColumnLayout {
+            Column {
                 id: materialDetails
-                width: 212
+                width: parent.width
                 height: 40
 
                 TextBody {
@@ -66,6 +73,8 @@ Item {
                     Layout.preferredWidth: parent.width
                     wrapMode: Text.WordWrap
                     text: filamentColorName.toUpperCase()
+                    visible: spoolPresent
+                    width: parent.width
                 }
 
                 TextBody {
@@ -73,6 +82,19 @@ Item {
                     style: TextBody.Base
                     font.weight: Font.Thin
                     text: qsTr("%1KG REMAINING").arg(filamentQuantity)
+                    visible: spoolPresent
+                    width: parent.width
+                }
+
+                TextBody {
+                    id: noTagWarningText
+                    visible: {
+                        bot.hasFilamentBay && !spoolPresent && filamentMaterial != 'unknown'
+                    }
+                    style: TextBody.Base
+                    font.weight: Font.Thin
+                    text: qsTr("COULD NOT READ SPOOL INFO")
+                    width: parent.width
                 }
             }
         }
@@ -90,7 +112,7 @@ Item {
         },
         State {
             name: "extruder_present_material_details_unknown"
-            when: extruderPresent && (!bot.hasFilamentBay || !spoolPresent)
+            when: extruderPresent && !bot.hasFilamentBay
 
             PropertyChanges {
                 target: contentContainer
@@ -104,7 +126,7 @@ Item {
         },
         State {
             name: "extruder_present_material_details_known"
-            when: extruderPresent && bot.hasFilamentBay && spoolPresent
+            when: extruderPresent && bot.hasFilamentBay
 
             PropertyChanges {
                 target: contentContainer


### PR DESCRIPTION
* If the user tries to load through the filament bay and no tag is detected, offer them to manually select filament type from list of supported for the attached extruder
* Make acknowledge_material accept a material type to support the above
* In Material page, prioritize showing name of loaded material as reported by spool journal, rather than the spool name
* Set load material retry properties when loading through FRE