### PR TITLE
Don't permanently dismiss the NFC bypass popup

### DIFF
--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -2139,8 +2139,11 @@ void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {
 
     // Update process info last so that data that is synced to process
     // steps will be up to date when we fire the step change event
-    dynamic_cast<KaitenProcessModel*>(m_process.data())->procUpdate(
-        info["current_process"]);
+    const Json::Value & process = info["current_process"];
+    if (!process.isObject()) {
+        spoolValidityCheckPendingReset();
+    }
+    dynamic_cast<KaitenProcessModel*>(m_process.data())->procUpdate(process);
 }
 
 bool KaitenBotModel::checkError(const Json::Value error_list,


### PR DESCRIPTION
The trigger for showing the popup that allows NFC bypass is a mechanism that was previously only used for informational warnings about the user doing something they were not supposed to do.  This mechanism has always been a bit broken but it previously wasn't really a big deal.  The way that the mechanism works is that we have a flag that is set to true by an incoming message from the loading process in kaiten but is only set to false when the UI tells kaiten to proceed with filament loading.  The popup is only triggered when this flag transitions from false to true, so when kaiten sends a message that would set the flag to true but the flag is already true, the popup is not triggered.  The NFC bypass popup is the only way to get the UI to tell kaiten to proceed with filament loading when there is no functioning NFC tag/reader so in this situation the dismissal is permanent.

The quick fix here is just to also set this flag to false whenever the machine is idle.  Longer term I do feel like a much larger refactor is the way to go...