### PR TITLE
Add the mesh calibration UI

### DIFF
--- a/src/model/bot_model.cpp
+++ b/src/model/bot_model.cpp
@@ -386,6 +386,14 @@ void BotModel::getPrintAgainEnabled() {
     qDebug() << FL_STRM << "called";
 }
 
+void BotModel::enableMesh(bool enable) {
+    qDebug() << FL_STRM << "called with params:" << " enable: " << enable;
+}
+
+void BotModel::calibrateMesh() {
+    qDebug() << FL_STRM << "called";
+}
+
 class DummyBotModel : public BotModel {
   public:
     DummyBotModel() {

--- a/src/model/bot_model.h
+++ b/src/model/bot_model.h
@@ -123,6 +123,8 @@ class BotModel : public BaseModel {
     Q_INVOKABLE virtual void setBuildPlateZeroZOffset(float tool_a_z_offset, float tool_b_z_offset);
     Q_INVOKABLE virtual void setPrintAgainEnabled(bool enable);
     Q_INVOKABLE virtual void getPrintAgainEnabled();
+    Q_INVOKABLE virtual void enableMesh(bool enable);
+    Q_INVOKABLE virtual void calibrateMesh();
 
     QStringList firmwareReleaseNotesList();
     void firmwareReleaseNotesListSet(QStringList &releaseNotesList);
@@ -408,6 +410,10 @@ class BotModel : public BaseModel {
     MODEL_PROP(float, lastAutoCalOffsetBX, -999.999)
     MODEL_PROP(float, lastAutoCalOffsetBY, -999.999)
     MODEL_PROP(float, lastAutoCalOffsetBZ, -999.999)
+
+    // Mesh Calibration
+    MODEL_PROP(bool, meshCalAvailable, false);
+    MODEL_PROP(bool, meshCalEnabled, false);
 
     // Accessories
     // Oyster - HEPA Filter Lid

--- a/src/model/process_model.h
+++ b/src/model/process_model.h
@@ -23,6 +23,7 @@ class ProcessModel : public BaseModel {
         NozzleCleaningProcess,
         AnnealPrintProcess,
         MoveBuildPlateProcess,
+        MeshCalibrationProcess,
         Other
     };
     //MOREPORK_QML_ENUM
@@ -73,7 +74,9 @@ class ProcessModel : public BaseModel {
         WaitingForSpool,
         DryingSpool,
         WaitingForPart, // Anneal print process states
-        AnnealingPrint
+        AnnealingPrint,
+        CalibratingMesh, // Mesh calibration
+        HeatingChamber
     };
     //MOREPORK_QML_ENUM
     enum ErrorType {

--- a/src/model_impl/kaiten_bot_model.cpp
+++ b/src/model_impl/kaiten_bot_model.cpp
@@ -129,6 +129,8 @@ class KaitenBotModel : public BotModel {
     void setPrintAgainEnabled(bool enable);
     void getPrintAgainEnabled();
     void printAgainEnabledUdpdate(const Json::Value &result);
+    void enableMesh(bool enable);
+    void calibrateMesh();
 
     QScopedPointer<LocalJsonRpc, QScopedPointerDeleteLater> m_conn;
     void connected();
@@ -1715,6 +1717,33 @@ void KaitenBotModel::getPrintAgainEnabled() {
     }
 }
 
+void KaitenBotModel::enableMesh(bool enable) {
+    try{
+        qDebug() << FL_STRM << "called";
+        auto conn = m_conn.data();
+
+        Json::Value json_params(Json::objectValue);
+        json_params["enable"] = Json::Value(enable);
+
+        conn->jsonrpc.invoke("enable_mesh", json_params, std::weak_ptr<JsonRpcCallback>());
+    }
+    catch(JsonRpcInvalidOutputStream &e){
+        qWarning() << FFL_STRM << e.what();
+    }
+}
+
+void KaitenBotModel::calibrateMesh() {
+    try{
+        qDebug() << FL_STRM << "called";
+        auto conn = m_conn.data();
+
+        conn->jsonrpc.invoke("calibrate_mesh", Json::Value(), std::weak_ptr<JsonRpcCallback>());
+    }
+    catch(JsonRpcInvalidOutputStream &e){
+        qWarning() << FFL_STRM << e.what();
+    }
+}
+
 KaitenBotModel::KaitenBotModel(const char * socketpath) :
         m_conn(new LocalJsonRpc(socketpath)),
         m_sysNot(new SystemNotification(this)),
@@ -2135,6 +2164,15 @@ void KaitenBotModel::sysInfoUpdate(const Json::Value &info) {
       } else {
           versionReset();
       }
+    }
+
+    const Json::Value & mesh_enabled = info["mesh_enabled"];
+    if (!mesh_enabled.isBool()) {
+        meshCalEnabledSet(false);
+        meshCalAvailableSet(false);
+    } else {
+        meshCalAvailableSet(true);
+        meshCalEnabledSet(mesh_enabled.asBool());
     }
 
     // Update process info last so that data that is synced to process

--- a/src/model_impl/kaiten_process_model.cpp
+++ b/src/model_impl/kaiten_process_model.cpp
@@ -16,6 +16,12 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
         kStepStr = kStep.asString().c_str();
     }
 
+    const Json::Value &kName = proc["name"];
+    QString kNameStr;
+    if (kName.isString()) {
+        kNameStr = kName.asString().c_str();
+    }
+
     if(kStepStr == "clear_build_plate") {
         isBuildPlateClearSet(true);
     } else {
@@ -195,7 +201,6 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
     // see morepork-kaiten/kaiten/src/kaiten/processes/printprocess.py
     if (kStepStr == "initializing" ||
         kStepStr == "initial_heating" ||
-        kStepStr == "heating_chamber" ||
         kStepStr == "heating_build_platform" ||
         kStepStr == "final_heating" ||
         kStepStr == "cooling" ||
@@ -206,6 +211,8 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
         kStepStr == "waiting_for_file" ||
         kStepStr == "transfer" ||
         kStepStr == "downloadingext")
+        stateTypeSet(ProcessStateType::Loading);
+    else if (kStepStr == "heating_chamber" && kNameStr == "PrintProcess")
         stateTypeSet(ProcessStateType::Loading);
     else if (kStepStr == "suspending")
         stateTypeSet(ProcessStateType::Pausing);
@@ -324,15 +331,17 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
     // 'heating_chamber' step maps to 'Loading' ProcessStateType on the UI.
     else if (kStepStr == "annealing_print")
         stateTypeSet(ProcessStateType::AnnealingPrint);
+    else if (kStepStr == "calibrating_mesh")
+        stateTypeSet(ProcessStateType::CalibratingMesh);
+    else if (kStepStr == "heating_chamber")
+        stateTypeSet(ProcessStateType::HeatingChamber);
     else
         stateTypeReset();
 
     // Set the process type last so that any listeners on this property
     // that are waiting for a new process to start will see up to date
     // properties for that process when they fire.
-    const Json::Value &kName = proc["name"];
     if (kName.isString()) {
-        const QString kNameStr = kName.asString().c_str();
         nameStrSet(kNameStr);
         if (kNameStr == "PrintProcess")
             typeSet(ProcessType::Print);
@@ -358,6 +367,8 @@ void KaitenProcessModel::procUpdate(const Json::Value &proc) {
             typeSet(ProcessType::AnnealPrintProcess);
         else if (kNameStr == "MoveBuildPlateProcess")
             typeSet(ProcessType::MoveBuildPlateProcess);
+        else if (kNameStr == "MeshCalibrationProcess")
+            typeSet(ProcessType::MeshCalibrationProcess);
         else
             typeSet(ProcessType::None);
     }

--- a/src/qml/BuildPlateSettingsPage.qml
+++ b/src/qml/BuildPlateSettingsPage.qml
@@ -11,4 +11,8 @@ BuildPlateSettingsPageForm {
     buttonMoveBuildPlatePage.onClicked: {
         buildPlateSettingsSwipeView.swipeToItem(BuildPlateSettingsPage.RaiseLowerBuildPlatePage)
     }
+
+    buttonMeshCalibration.onClicked: {
+        buildPlateSettingsSwipeView.swipeToItem(BuildPlateSettingsPage.MeshCalibrationPage)
+    }
 }

--- a/src/qml/BuildPlateSettingsPageForm.qml
+++ b/src/qml/BuildPlateSettingsPageForm.qml
@@ -19,10 +19,15 @@ Item {
     property alias moveBuildPlatePage: moveBuildPlatePage
     property alias buttonMoveBuildPlatePage: buttonMoveBuildPlatePage
 
+    property alias meshCalibration: meshCalibration
+    property alias meshErrorScreen: meshErrorScreen
+    property alias buttonMeshCalibration: buttonMeshCalibration
+
     enum SwipeIndex {
         BasePage,                   //0
         AssistedLevelingPage,       //1
-        RaiseLowerBuildPlatePage    //2
+        RaiseLowerBuildPlatePage,   //2
+        MeshCalibrationPage         //3
     }
 
     LoggingStackLayout {
@@ -64,6 +69,27 @@ Item {
                         buttonImage.source: "qrc:/img/icon_raise_lower_bp.png"
                         buttonText.text: qsTr("RAISE/LOWER BUILD PLATE")
                         enabled: !isProcessRunning()
+                    }
+
+                    MenuButton {
+                        id: buttonMeshCalibration
+                        buttonImage.source: "qrc:/img/icon_mesh.png"
+                        buttonText.text: qsTr("MESH BED LEVELING")
+                        enabled: !isProcessRunning()
+                        slidingSwitch.checked: bot.meshCalEnabled
+                        slidingSwitch.checkable: bot.meshCalAvailable
+                        slidingSwitch.visible: true
+
+                        slidingSwitch.onClicked: {
+                            if (!bot.meshCalAvailable) {
+                                buildPlateSettingsSwipeView.swipeToItem(
+                                    BuildPlateSettingsPage.MeshCalibrationPage);
+                            } else if (!slidingSwitch.checked) {
+                                bot.enableMesh(false);
+                            } else {
+                                bot.enableMesh(true);
+                            }
+                        }
                     }
                 }
             }
@@ -117,7 +143,7 @@ Item {
             }
         }
 
-        // BuildPlateSettingsPage.MoveBuildPlatePage
+        // BuildPlateSettingsPage.RaiseLowerBuildPlatePage
         Item {
             id: moveBuildPlatePageItem
             property var backSwiper: buildPlateSettingsSwipeView
@@ -128,6 +154,53 @@ Item {
 
             MoveBuildPlatePage {
                 id: moveBuildPlatePage
+            }
+        }
+
+        // BuildPlateSettingsPage.MeshCalibrationPage
+        Item {
+            id: meshCalibrationPageItem
+            property var backSwiper: buildPlateSettingsSwipeView
+            property int backSwipeIndex: BuildPlateSettingsPage.BasePage
+            property string topBarTitle: qsTr("Calibrate Bed Mesh")
+            property bool hasAltBack: true
+            smooth: false
+            visible: false
+
+            function altBack() {
+                if (meshCalibration.chooseMaterial) {
+                    meshCalibration.chooseMaterial = false;
+                } else if (bot.process.type == ProcessType.MeshCalibrationProcess) {
+                    meshCalibration.cancelCalibrationPopup.open()
+                } else if (meshCalibration.state == "install_build_plate") {
+                    meshCalibration.state = "base state"
+                } else if (meshCalibration.state == "secure_build_plate") {
+                    meshCalibration.state = "install_build_plate"
+                } else {
+                    meshCalibration.state = "base state"
+                    meshErrorScreen.acknowledgeError()
+                    buildPlateSettingsSwipeView.swipeToItem(BuildPlateSettingsPage.BasePage)
+                }
+            }
+
+            MeshCalibration {
+                id: meshCalibration
+                visible: !meshErrorScreen.visible
+                onProcessDone: {
+                    state = "base state"
+                    if (meshErrorScreen.lastReportedErrorType == ErrorType.NoError) {
+                        buildPlateSettingsSwipeView.swipeToItem(BuildPlateSettingsPage.BasePage)
+                    }
+                }
+            }
+
+            ErrorScreen {
+                id: meshErrorScreen
+                isActive: bot.process.type == ProcessType.MeshCalibrationProcess
+                visible: {
+                    lastReportedProcessType == ProcessType.MeshCalibrationProcess &&
+                    lastReportedErrorType != ErrorType.NoError
+                }
             }
         }
     }

--- a/src/qml/CleanExtruderSettings.qml
+++ b/src/qml/CleanExtruderSettings.qml
@@ -7,7 +7,7 @@ import ProcessTypeEnum 1.0
 
 CleanExtruderSettingsForm {
     function startCleaning(temp_list) {
-        if(bot.process.type == ProcessType.CalibrationProcess) {
+        if(bot.process.type !== ProcessType.None) {
             // Calls process method to perform nozzle cleaning in
             // 'Nozzle Calibration' Kaiten Process
             bot.doNozzleCleaning(true, temp_list)

--- a/src/qml/MeshCalibration.qml
+++ b/src/qml/MeshCalibration.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.10
+import ProcessStateTypeEnum 1.0
+import ExtruderTypeEnum 1.0
+
+MeshCalibrationForm {
+    contentRightSide {
+        buttonPrimary {
+            onClicked: {
+                if (state == "calibration_finished") {
+                    meshCalibration.processDone()
+                } else if (state == "install_build_plate") {
+                    meshCalibration.state = "secure_build_plate"
+                } else if (state == "secure_build_plate") {
+                    bot.calibrateMesh()
+                } else {
+                    // Button action in 'base state'
+                    meshCalibration.state = "install_build_plate"
+                }
+            }
+        }
+    }
+
+    cleanExtrudersSequence {
+        contentRightSide {
+            buttonPrimary {
+                onClicked: {
+                    if (meshCalibration.state == "clean_nozzles" &&
+                            bot.process.stateType == ProcessStateType.CheckNozzleClean) {
+                        if (bot.extruderAType == ExtruderType.MK14_EXP) {
+                            meshCalibration.chooseMaterial = true
+                        } else {
+                            bot.doNozzleCleaning(true)
+                        }
+                    } else if (meshCalibration.state == "clean_nozzles" &&
+                            bot.process.stateType == ProcessStateType.FinishCleaning) {
+                        bot.acknowledgeNozzleCleaned(true)
+                    }
+                }
+            }
+
+            buttonSecondary1 {
+                onClicked: {
+                    if (meshCalibration.state == "clean_nozzles" &&
+                            bot.process.stateType == ProcessStateType.CheckNozzleClean) {
+                        bot.doNozzleCleaning(false)
+                    } else if (meshCalibration.state == "clean_nozzles" &&
+                            bot.process.stateType == ProcessStateType.FinishCleaning) {
+                        bot.acknowledgeNozzleCleaned(false)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/MeshCalibrationForm.qml
+++ b/src/qml/MeshCalibrationForm.qml
@@ -1,0 +1,603 @@
+import QtQuick 2.10
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import ProcessTypeEnum 1.0
+import ProcessStateTypeEnum 1.0
+import ErrorTypeEnum 1.0
+import ExtruderTypeEnum 1.0
+
+LoggingItem {
+    itemName: "MeshCalibration"
+    id: calibrationPage
+    width: 800
+    height: 408
+    property alias contentLeftSide: contentLeftSide
+    property alias contentRightSide: contentRightSide
+    property alias cleanExtrudersSequence: cleanExtrudersSequence
+    property alias cancelCalibrationPopup: cancelCalibrationPopup
+    signal processDone
+
+    property int currentState: bot.process.stateType
+    onCurrentStateChanged: {
+        if (bot.process.type == ProcessType.MeshCalibrationProcess) {
+            console.info(currentState);
+            switch (currentState) {
+            case ProcessStateType.Cancelling:
+                state = "cancelling"
+                break;
+            case ProcessStateType.CleaningUp:
+               if (!bot.process.cancelled) {
+                   state = "calibration_finished"
+               }
+               break;
+            default:
+                break;
+            }
+        }
+        else if(bot.process.type == ProcessType.None) {
+            if (state == "cancelling") {
+                processDone()
+            }
+        }
+    }
+
+    property bool chooseMaterial: false
+
+    ContentLeftSide {
+        id: contentLeftSide
+        image {
+            source: ("qrc:/img/%1.png").arg(getImageForPrinter("mesh_cal"))
+            visible: true
+        }
+        processStatusIcon {
+            visible: false
+        }
+        visible: true
+    }
+
+    ContentRightSide {
+        id: contentRightSide
+        textHeader {
+            text: qsTr("MESH BED LEVELING")
+            visible: true
+        }
+        textBody {
+            text: qsTr("Mesh bed leveling maps the surface of the print bed at " +
+                       "multiple points to create a height map. This process " +
+                       "compensates for any irregularities, improving " +
+                       "first-layer adhesion and print accuracy.")
+            visible: true
+        }
+        buttonPrimary {
+            text: qsTr("NEXT")
+            visible: true
+        }
+        visible: true
+    }
+
+    CleanExtrudersSequence {
+        id: cleanExtrudersSequence
+        anchors.verticalCenter: parent.verticalCenter
+        visible: false
+        enabled: bot.process.type == ProcessType.MeshCalibrationProcess
+    }
+
+    CleanExtruderSettings {
+        id: materialSelector
+        visible: false
+    }
+
+    states: [
+        // Stupid stupid QML bug (quirk?) that just wont let the screen go back
+        // to its default built-in "base state" at the end of the process even
+        // when explicitly assigned to, unless making a clone of the base state
+        // with the same name. I hate myself for spending a day tracking this
+        // down convinced that it was me.
+        State {
+            name: "base state"
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+                image {
+                    visible: true
+                }
+                animatedImage {
+                    visible: false
+                }
+                processStatusIcon {
+                    visible: false
+                }
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                visible: true
+            }
+
+            PropertyChanges {
+                target: cleanExtrudersSequence
+                visible: false
+            }
+
+            PropertyChanges {
+                target: materialSelector
+                visible: false
+            }
+        },
+
+        State {
+            name: "clean_nozzles"
+            when: bot.process.type == ProcessType.MeshCalibrationProcess &&
+                  (bot.process.stateType == ProcessStateType.CheckNozzleClean ||
+                   bot.process.stateType == ProcessStateType.HeatingNozzle ||
+                   bot.process.stateType == ProcessStateType.CleanNozzle ||
+                   bot.process.stateType == ProcessStateType.FinishCleaning ||
+                   bot.process.stateType == ProcessStateType.CoolingNozzle) &&
+                  !chooseMaterial
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                visible: false
+            }
+
+            PropertyChanges {
+                target: cleanExtrudersSequence
+                visible: true
+            }
+
+            PropertyChanges {
+                target: materialSelector
+                visible: false
+            }
+        },
+
+        State {
+            name: "choose_material"
+            when: bot.process.type == ProcessType.MeshCalibrationProcess &&
+                  bot.process.stateType == ProcessStateType.CheckNozzleClean &&
+                  chooseMaterial
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: false
+            }
+
+            PropertyChanges {
+                target: cleanExtrudersSequence
+                visible: false
+            }
+
+            PropertyChanges {
+                target: materialSelector
+                visible: true
+            }
+        },
+
+        State {
+            name: "install_build_plate"
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                source: ("qrc:/img/%1.gif").arg(getImageForPrinter("insert_build_plate"))
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("INSERT BUILD PLATE")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                text: qsTr("Insert the build plate by first placing the rear edge down and sliding it back until it fits snugly and looks aligned.")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                text: qsTr("NEXT")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: cleanExtrudersSequence
+                visible: false
+            }
+
+            PropertyChanges {
+                target: materialSelector
+                visible: false
+            }
+        },
+        State {
+            name: "secure_build_plate"
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                source: "qrc:/img/secure_build_plate.png"
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("CONFIRM AND CLOSE DOOR")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                text: qsTr("Check the corners of your build plate to ensure it is secured properly.")+
+                      "\n\n"+ qsTr("The build plate should be flush.")
+
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                text: qsTr("NEXT")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: cleanExtrudersSequence
+                visible: false
+            }
+
+            PropertyChanges {
+                target: materialSelector
+                visible: false
+            }
+        },
+
+        State {
+            name: "getting_ready"
+            when: bot.process.type == ProcessType.MeshCalibrationProcess &&
+                  bot.process.stateType == ProcessStateType.CalibratingToolheads
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                processStatus: ProcessStatusIcon.Loading
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("GETTING READY")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                visible: false
+            }
+        },
+
+        State {
+            name: "heating_chamber"
+            when: bot.process.type == ProcessType.MeshCalibrationProcess &&
+                  bot.process.stateType == ProcessStateType.HeatingChamber
+
+            PropertyChanges {
+                target: contentLeftSide
+                image {
+                    visible: false
+                }
+                processStatusIcon {
+                    processStatus: ProcessStatusIcon.Loading
+                    visible: true
+                }
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                textHeader {
+                    text: qsTr("HEATING")
+                    visible: true
+                }
+                temperatureStatus {
+                    showComponent: TemperatureStatus.ChamberAndHeatedBuildPlate
+                    visible: true
+                }
+                textBody {
+                    visible: false
+                }
+                buttonPrimary {
+                    visible: false
+                }
+            }
+        },
+
+        State {
+            name: "calibrating"
+            when: bot.process.type == ProcessType.MeshCalibrationProcess &&
+                  bot.process.stateType == ProcessStateType.CalibratingMesh
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                processStatus: ProcessStatusIcon.Loading
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("CALIBRATING")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                text: qsTr("Please wait while the printer calibrates.")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                visible: false
+            }
+        },
+
+        State {
+            name: "calibration_finished"
+
+            // See switch case at top of file for the logic
+            // to get into this state
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                processStatus: ProcessStatusIcon.Success
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("CALIBRATION SUCCESSFUL")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                text: qsTr("This bed mesh is now calibrated and can be used for printing.")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                text: qsTr("DONE")
+                visible: true
+            }
+        },
+
+        State {
+            name: "cancelling"
+
+            PropertyChanges {
+                target: contentLeftSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.processStatusIcon
+                processStatus: ProcessStatusIcon.Loading
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.image
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentLeftSide.animatedImage
+                visible: false
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textHeader
+                text: qsTr("CANCELLING CALIBRATION")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.textBody
+                text: qsTr("Please wait")
+                visible: true
+            }
+
+            PropertyChanges {
+                target: contentRightSide.buttonPrimary
+                visible: false
+            }
+        }
+    ]
+
+    CustomPopup {
+        popupName: "CancelCalibration"
+        id: cancelCalibrationPopup
+        popupWidth: 720
+        popupHeight: 250
+        showTwoButtons: true
+
+        leftButtonText: qsTr("BACK")
+        leftButton.onClicked: {
+            cancelCalibrationPopup.close()
+        }
+
+        rightButtonText: qsTr("CONFIRM")
+        rightButton.onClicked: {
+            state = "cancelling"
+            bot.cancel()
+            cancelCalibrationPopup.close()
+        }
+
+        ColumnLayout {
+            id: columnLayout
+            width: 590
+            height: 100
+            anchors.top: parent.top
+            anchors.topMargin: 145
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            TextHeadline {
+                text: qsTr("CANCEL CALIBRATION")
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            }
+
+            TextBody {
+                text: qsTr("Are you sure you want to cancel the calibration process?")
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            }
+        }
+    }
+}

--- a/src/qml/TemperatureStatus.qml
+++ b/src/qml/TemperatureStatus.qml
@@ -106,6 +106,7 @@ ColumnLayout {
             }
         }
         visible: showComponent == TemperatureStatus.BothExtruders ||
-                 showComponent == TemperatureStatus.ChamberAndHeatedBuildPlate
+                 (showComponent == TemperatureStatus.ChamberAndHeatedBuildPlate &&
+                  bot.machineType == MachineType.Magma)
     }
 }

--- a/src/qml/images/icon_mesh.png
+++ b/src/qml/images/icon_mesh.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c979d2b1edc44df9b64267b79283b1f6bd578719708c8815abe597f0303b24b3
+size 812

--- a/src/qml/images/method_mesh_cal.png
+++ b/src/qml/images/method_mesh_cal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eaf37e029649ea3da3b6c9be030c9d2941b1ca34131fa829ddf6cdf87bfd223
+size 80431

--- a/src/qml/images/methodxl_mesh_cal.png
+++ b/src/qml/images/methodxl_mesh_cal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fc206f6709d77889767e8b4b6938a868a78ce80d5890c63af13e521d755dd5d
+size 96004

--- a/src/qml/media.qrc
+++ b/src/qml/media.qrc
@@ -260,5 +260,8 @@
         <file alias="wifi_low.png">images/wifi_low.png</file>
         <file alias="wifi_medium.png">images/wifi_medium.png</file>
         <file alias="wifi_strong.png">images/wifi_strong.png</file>
+        <file alias="method_mesh_cal.png">images/method_mesh_cal.png</file>
+        <file alias="methodxl_mesh_cal.png">images/methodxl_mesh_cal.png</file>
+        <file alias="icon_mesh.png">images/icon_mesh.png</file>
     </qresource>
 </RCC>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -297,5 +297,7 @@
         <file>AnnealMenuForm.qml</file>
         <file>AboutPage.qml</file>
         <file>AboutPageForm.qml</file>
+        <file>MeshCalibration.qml</file>
+        <file>MeshCalibrationForm.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
A new mesh calibration flow was added under the build plate settings menu, including prompts for making sure the build plate is seated and cleaning the extruders.  The menu button to access this flow also includes a toggle switch to turn mesh compensation on or off, and attempting to toggle mesh compensation on while there is no available mesh data will enter the mesh calibration flow.

The temperature status component has been updated so that specifying "chamber and build plate" on a machine with no build plate will fall back to just displaying the build plate.